### PR TITLE
change config vars to lowercase and minor polish to readmes

### DIFF
--- a/instagram-auth/README.md
+++ b/instagram-auth/README.md
@@ -17,10 +17,10 @@ Create and provide a Service Account's credentials:
 Create and setup your Instagram app:
  1. Register an Instagram app on [Instagram for Developers](https://www.instagram.com/developer/). You'll need to **Register a New Client**.
  1. Once Your app is created make sure you specify your app's callback URL in the list of **Valid redirect URIs** of your Instagram app. You should whitelist `https://localhost:5000/popup.html` for local development and if you deploy on App Engine (See Deploy section below) you should whitelist the URL `https://<application-id>.firebaseapp.com/popup.html`.
- 1. Copy the **Client ID** and **Client Secret** of your Instagram app and use them to set the `instagram.clientId` and `instagram.clientSecret` Google Cloud environment variables. For this use:
+ 1. Copy the **Client ID** and **Client Secret** of your Instagram app and use them to set the `instagram.client_id` and `instagram.client_secret` Google Cloud environment variables. For this use:
 
 ```bash
-firebase functions:config:set instagram.clientId="yourClientID" instagram.clientSecret="yourClientSecret"
+firebase functions:config:set instagram.client_id="yourClientID" instagram.client_secret="yourClientSecret"
 ```
 
  > Make sure the Instagram Client Secret is always kept secret. For instance do not save it in your version control system.
@@ -40,7 +40,7 @@ The website should display your name and profile pic from Instagram. At this poi
 
 ## Workflow and design
 
-When Clicking the **Sign in with Instagram** button a popup is shown which redirects users to the `redirect` Function URL.
+When clicking the **Sign in with Instagram** button a popup is shown which redirects users to the `redirect` Function URL.
 
 The `redirect` Function then redirects the user to the Instagram OAuth 2.0 consent screen where (the first time only) the user will have to grant approval. Also the `state` cookie is set on the client with the value of the `state` URL query parameter to check against later on.
 

--- a/instagram-auth/functions/index.js
+++ b/instagram-auth/functions/index.js
@@ -35,11 +35,11 @@ const OAUTH_SCOPES = 'basic';
  */
 function instagramOAuth2Client() {
   // Instagram OAuth 2 setup
-  // TODO: Configure the `instagram.clientId` and `instagram.clientSecret` Google Cloud environment variables.
+  // TODO: Configure the `instagram.client_id` and `instagram.client_secret` Google Cloud environment variables.
   const credentials = {
     client: {
-      id: functions.config().instagram.clientId,
-      secret: functions.config().instagram.clientSecret
+      id: functions.config().instagram.client_id,
+      secret: functions.config().instagram.client_secret
     },
     auth: {
       tokenHost: 'https://api.instagram.com',

--- a/linkedin-auth/README.md
+++ b/linkedin-auth/README.md
@@ -18,10 +18,10 @@ Create and setup your LinkedIn app:
  1. Create a LinkedIn app in the [LinkedIn Developers website](https://www.linkedin.com/developer/apps/).
  1. Add the URL `https://<application-id>.firebaseapp.com/popup.html` to the
     **OAuth 2.0** > **Authorized Redirect URLs** of your LinkedIn app.
- 1. Copy the **Client ID** and **Client Secret** of your LinkedIn app and use them to set the `linkedIn.clientId` and `linkedIn.clientSecret` Google Cloud environment variables. For this use:
+ 1. Copy the **Client ID** and **Client Secret** of your LinkedIn app and use them to set the `linkedin.client_id` and `linkedin.client_secret` Google Cloud environment variables. For this use:
 
 ```bash
-firebase functions:config:set linkedIn.clientId="yourClientID" linkedIn.clientSecret="yourClientSecret"
+firebase functions:config:set linkedin.client_id="yourClientID" linkedin.client_secret="yourClientSecret"
 ```
 
  > Make sure the LinkedIn Client Secret is always kept secret. For instance do not save this in your version control system.
@@ -35,13 +35,13 @@ Deploy your project:
 
 Open the sample's website by using `firebase open hosting:site` or directly accessing `https://<project-id>.firebaseapp.com/`.
 
-Click on the **Sign in with LinkedIn** button and a popup window will appear that will show the Linked In authentication consent screen. Sign In and/or authorize the authentication request.
+Click on the **Sign in with LinkedIn** button and a popup window will appear that will show the LinkedIn authentication consent screen. Sign In and/or authorize the authentication request.
 
-The website should display your name, email and profile pic from Linked In. At this point you are authenticated in Firebase and can use the database/hosting etc...
+The website should display your name, email and profile pic from LinkedIn. At this point you are authenticated in Firebase and can use the database/hosting etc...
 
 ## Workflow and design
 
-When Clicking the **Sign in with LinkedIn** button a popup is shown which redirects users to the `redirect` Function URL.
+When clicking the **Sign in with LinkedIn** button a popup is shown which redirects users to the `redirect` Function URL.
 
 The `redirect` Function then redirects the user to the LinkedIn OAuth 2.0 consent screen where (the first time only) the user will have to grant approval. Also the `state` cookie is set on the client with the value of the `state` URL query parameter to check against later on.
 

--- a/linkedin-auth/functions/index.js
+++ b/linkedin-auth/functions/index.js
@@ -34,10 +34,10 @@ const OAUTH_SCOPES = ['r_basicprofile', 'r_emailaddress'];
  */
 function linkedInClient() {
   // Instagram OAuth 2 setup
-  // TODO: Configure the `linkedIn.clientId` and `linkedIn.clientSecret` Google Cloud environment variables.
+  // TODO: Configure the `linkedin.client_id` and `linkedin.client_secret` Google Cloud environment variables.
   return require('node-linkedin')(
-      functions.config().linkedIn.clientId,
-      functions.config().linkedIn.clientSecret,
+      functions.config().linkedin.client_id,
+      functions.config().linkedin.client_secret,
       `https://${process.env.GCLOUD_PROJECT}.firebaseapp.com/popup.html`);
 }
 


### PR DESCRIPTION
`firebase functions:config:set` doesn't allow upper case letters in variables (think this is intended since it fires off an error `Error: Invalid config name linkedIn.clientId, cannot user upper case.`
 
Updated the readmes and the codes to use lowercase instead. Also some minor polishes:
 - Changing `Linked In` to `LinkedIn` in README
 - Lowercasing `Clicking` to `clicking`