### PR TITLE
Remove trailing comma from package.json

### DIFF
--- a/fcm-notifications/functions/package.json
+++ b/fcm-notifications/functions/package.json
@@ -3,6 +3,6 @@
   "description": "Send FCM notifications Firebase Functions sample",
   "dependencies": {
     "firebase-admin": "^4.1.1",
-    "firebase-functions": "https://storage.googleapis.com/firebase-preview-drop/node/firebase-functions/firebase-functions-preview.latest.tar.gz",
+    "firebase-functions": "https://storage.googleapis.com/firebase-preview-drop/node/firebase-functions/firebase-functions-preview.latest.tar.gz"
   }
 }


### PR DESCRIPTION
in fcm-notifications/functions

This was causing `npm install` to fail for me.