### PR TITLE
Fix/convert use spawn

### DIFF
--- a/generate-thumbnail/functions/index.js
+++ b/generate-thumbnail/functions/index.js
@@ -18,7 +18,7 @@
 const functions = require('firebase-functions');
 const mkdirp = require('mkdirp-promise');
 const gcs = require('@google-cloud/storage')();
-const exec = require('child-process-promise').exec;
+const spawn = require('child-process-promise').spawn;
 const LOCAL_TMP_FOLDER = '/tmp/';
 
 // Max height and width of the thumbnail in pixels.
@@ -68,7 +68,7 @@ exports.generateThumbnail = functions.storage.object().onChange(event => {
     }).then(() => {
       console.log('The file has been downloaded to', tempLocalFile);
       // Generate a thumbnail using ImageMagick.
-      return exec(`convert "${tempLocalFile}" -thumbnail '${THUMB_MAX_WIDTH}x${THUMB_MAX_HEIGHT}>' "${tempLocalThumbFile}"`).then(() => {
+      return spawn('convert', [tempLocalFile, '-thumbnail', `${THUMB_MAX_WIDTH}x${THUMB_MAX_HEIGHT}>`, tempLocalThumbFile]).then(() => {
         console.log('Thumbnail created at', tempLocalThumbFile);
         // Uploading the Thumbnail.
         return bucket.upload(tempLocalThumbFile, {

--- a/quickstarts/thumbnails/functions/index.js
+++ b/quickstarts/thumbnails/functions/index.js
@@ -18,7 +18,7 @@
 // [START import]
 const functions = require('firebase-functions');
 const gcs = require('@google-cloud/storage')();
-const exec = require('child-process-promise').exec;
+const spawn = require('child-process-promise').spawn;
 // [END import]
 
 // [START generateThumbnail]
@@ -69,7 +69,7 @@ exports.generateThumbnail = functions.storage.object().onChange(event => {
   }).then(() => {
     console.log('Image downloaded locally to', tempFilePath);
     // Generate a thumbnail using ImageMagick.
-    return exec(`convert "${tempFilePath}" -thumbnail '200x200>' "${tempFilePath}"`).then(() => {
+    return spawn('convert', [tempFilePath, '-thumbnail', '200x200>', tempFilePath]).then(() => {
       console.log('Thumbnail created at', tempFilePath);
       // We add a 'thumb_' prefix to thumbnails file name. That's where we'll upload the thumbnail.
       const thumbFilePath = filePath.replace(/(\/)?([^\/]*)$/, `$1thumb_$2`);


### PR DESCRIPTION
```
exec(`convert ${fileName}`)
```

exec is execute with shell. And The file name can contain $ {} ".
ex `test$(echo 2).gif`

use spawn or execFile.