### PR TITLE
Use transaction() instead of set() in the child-count sample

### DIFF
--- a/child-count/functions/index.js
+++ b/child-count/functions/index.js
@@ -21,5 +21,8 @@ admin.initializeApp(functions.config().firebase);
 
 // Keeps track of the length of the 'likes' child list in a separate attribute.
 exports.countlikes = functions.database.ref('/posts/{postid}/likes').onWrite(event => {
-  return event.data.ref.parent.child('likes_count').set(event.data.numChildren());
+  var likesCountRef = event.data.ref.parent.child('likes_count');
+  return likesCountRef.transaction(function(currentCount) {
+    return (currentCount || 0) + 1;
+  });
 });


### PR DESCRIPTION
Using `set()` can lead to race conditions where two children are added simultaneously and each set the value to N+1, instead of the first setting it to N+1 and the second setting it to N+2. Using `transaction()` properly gets rid of that race condition.

See [this Twitter thread](https://twitter.com/_jwngr/status/840063426151960577) for details.

cc/ @puf @aputinski - FYI