### PR TITLE
Omit path in DeltaSnapshot constructor in unit test to reduce confusion

### DIFF
--- a/quickstarts/uppercase/functions/test/test.js
+++ b/quickstarts/uppercase/functions/test/test.js
@@ -79,10 +79,11 @@ describe('Cloud Functions', () => {
         // data: any, delta: any, path?: string);
         // We can pass null for the first 2 parameters. The data parameter represents the state of
         // the database item before the event, while the delta parameter represents the change that
-        // occured to cause the event to fire. The last parameter is the database path.
-        data: new functions.database.DeltaSnapshot(null, null, null, 'input', 'messages/1111/original'),
+        // occured to cause the event to fire. The last parameter is the database path, which we are
+        // not making use of in this test. So we will omit it.
+        data: new functions.database.DeltaSnapshot(null, null, null, 'input'),
         // To mock a database delete event:
-        // data: new functions.database.DeltaSnapshot(null, null, 'old_data', null, 'messages/1111/original')
+        // data: new functions.database.DeltaSnapshot(null, null, 'old_data', null)
       };
       // [END fakeEvent]
 


### PR DESCRIPTION
https://github.com/firebase/functions-samples/issues/43

Having a path in the DeltaSnapshot constructor was confusing since it seemed like it would populate the params field of Event. But it doesn't actually do anything, so it's better to not have it. 