### PR TITLE
add payment source

### DIFF
--- a/stripe/functions/index.js
+++ b/stripe/functions/index.js
@@ -64,14 +64,14 @@ exports.createStripeCustomer = functions.auth.user().onCreate(event => {
 });
 
 // Add a payment source (card) for a user by writing a stripe payment source token to Realtime database
-exports.addPaymentSource = functions.database.ref('/stripe_customers/{userId}/cards/{token}').onWrite(event => {
-  const token = event.data.val();
+exports.addPaymentSource = functions.database.ref('/stripe_customers/{userId}/cards/{pushId}/token').onWrite(event => {
+  const source = event.data.val();
   const user = event.params.userId;
   return stripe.customers.createSource(
     user,
-    {source: token}
+    {source}
   ).then(response => {
-        return console.log('payment source added successfully for user', user);
+        return event.data.ref.parent.set(response);
   }, error => {
       return event.data.ref.child('error').set(userFacingMessage(error)).then(() => {
         return reportError(error, {user: user});


### PR DESCRIPTION
In the current Firebase Cloud Function example, users lack the ability to add a payment source that they can later initiate a charge on