### PR TITLE
(fulltext-search example): database event notation ($ to {})

### DIFF
--- a/fulltext-search/functions/index.js
+++ b/fulltext-search/functions/index.js
@@ -23,7 +23,7 @@ admin.initializeApp(functions.config().firebase);
 const algoliasearch = require('algoliasearch');
 
 // Updates the search index when new blog entries are created or updated.
-exports.indexentry = functions.database.ref('/blog-posts/$blogid').onWrite(event => {
+exports.indexentry = functions.database.ref('/blog-posts/{blogid}').onWrite(event => {
   // TODO: Make sure you configure the `algolia.key` and `algolia.secret` Google Cloud environment variables.
   const client = algoliasearch(functions.config().algolia.key, functions.config().algolia.secret);
   const index = client.initIndex('users');
@@ -37,7 +37,7 @@ exports.indexentry = functions.database.ref('/blog-posts/$blogid').onWrite(event
 
 // Starts a search query whenever a query is requested (by adding one to the `/search/queries`
 // element. Search results are then written under `/search/results`.
-exports.searchentry = functions.database.ref('/search/queries/$queryid').onWrite(event => {
+exports.searchentry = functions.database.ref('/search/queries/{queryid}').onWrite(event => {
   // TODO: Make sure you configure the `algolia.key` and `algolia.secret` Google Cloud environment variables.
   const client = algoliasearch(functions.config().algolia.key, functions.config().algolia.secret);
   const index = client.initIndex('users');


### PR DESCRIPTION
`$` notation for events (instead of `{}`) returns whole database data
within the `event.data.val()` instead of the data at the path of the event.

`{}` notation:
```js
exports.indexentry = functions.database.ref('/blog-posts/{blogid}').onWrite(event => {
...
```

`$` notation:
```js
exports.indexentry = functions.database.ref('/blog-posts/$blogid').onWrite(event => {
...
```

### How to reproduce these conditions

**Sample name or URL where you found the bug**

[fulltext-search example](https://github.com/firebase/functions-samples/blob/master/fulltext-search/functions/index.js)

**Steps to set up and reproduce**
1. Deploy  [fulltext-search example](https://github.com/firebase/functions-samples/blob/master/fulltext-search/functions/index.js) with a `console.log` to check `event.data.val()`
2. Push to `'/blog-posts`
3. See that `event.data.val()` is whole database data instead of just event's data

**Sample data pasted or attached as JSON (not an image)**

*Included in behavior sections below*

### Expected behavior
When event is triggered
1. Just event data is returned within the `event.data.val()`:

```js
{
  text: "post"
}
```
2. Event key is returned with `event.data.key`: `"0123ASDF"` or whatever push key the event has

### Actual behavior
When event is triggered
1. whole database is returned within the `event.data.val()`:

```js
{
  "blog-posts": {
    "0123ASDF": {
      text: "something"
    }
  },
  queries: {
    search: {
      query: "some",
    },
    results: {
      hits: [...]
    }
  },
  users: {
    "0EPGxlw6VPfH6z6GINWeC8VSKQC3": {
      displayName: "Some User",
      email: "some@email.com"
    }
  }
}
```
2. `undefined` is returned for `event.data.key`

### More Info

See [this Google Group topic](https://groups.google.com/forum/#!topic/firebase-functions-trusted-testers/PpJ4zdB6mAQ) for more information