### PR TITLE
Fix mistaken references to "instagram" in linkedin-auth

### DIFF
--- a/linkedin-auth/functions/index.js
+++ b/linkedin-auth/functions/index.js
@@ -33,7 +33,7 @@ const OAUTH_SCOPES = ['r_basicprofile', 'r_emailaddress'];
  * Creates a configured LinkedIn API Client instance.
  */
 function linkedInClient() {
-  // Instagram OAuth 2 setup
+  // LinkedIn OAuth 2 setup
   // TODO: Configure the `linkedin.client_id` and `linkedin.client_secret` Google Cloud environment variables.
   return require('node-linkedin')(
       functions.config().linkedin.client_id,
@@ -86,15 +86,15 @@ exports.token = functions.https.onRequest((req, res) => {
           }
           console.log('Auth code exchange result received:', userResults);
 
-          // We have an Instagram access token and the user identity now.
+          // We have a LinkedIn access token and the user identity now.
           const accessToken = results.access_token;
-          const instagramUserID = userResults.id;
+          const linkedInUserID = userResults.id;
           const profilePic = userResults.pictureUrl;
           const userName = userResults.formattedName;
           const email = userResults.emailAddress;
 
           // Create a Firebase account and get the Custom Auth Token.
-          createFirebaseAccount(instagramUserID, userName, profilePic, email, accessToken).then(
+          createFirebaseAccount(linkedInUserID, userName, profilePic, email, accessToken).then(
               firebaseToken => {
                 // Serve an HTML page that signs the user in and updates the user profile.
                 res.jsonp({token: firebaseToken});


### PR DESCRIPTION
It looks like a previous revision of the linkedin-auth Cloud Functions sample used Instagram instead of LinkedIn; there were a few references to "instagram" still hanging around the code.