### PR TITLE
Fixes 'bigquery.dataset' is not a function error

### DIFF
--- a/bigquery-import/functions/index.js
+++ b/bigquery-import/functions/index.js
@@ -16,7 +16,7 @@
 'use strict';
 
 const functions = require('firebase-functions');
-const bigquery = require('@google-cloud/bigquery');
+const bigquery = require('@google-cloud/bigquery')();
 
 /**
  * Writes all logs from the Realtime Database into bigquery.


### PR DESCRIPTION
Fixes 'bigquery.dataset' is not a function error after deploying and running the function.