### PR TITLE
Replace source with event parameter

### DIFF
--- a/message-translation/functions/index.js
+++ b/message-translation/functions/index.js
@@ -29,12 +29,11 @@ exports.translate = functions.database.ref('/messages/{languageID}/{messageID}')
   if (snapshot.val().translated) {
     return;
   }
-  const paths = snapshot.ref.toString().split('/');
   const promises = [];
   for (let i = 0; i < LANGUAGES.length; i++) {
     var language = LANGUAGES[i];
-    if (language !== paths[1]) {
-      promises.push(createTranslationPromise(paths[1], language, snapshot));
+    if (language !== event.params.languageID) {
+      promises.push(createTranslationPromise(event.params.languageID, language, snapshot));
     }
   }
   return Promise.all(promises);


### PR DESCRIPTION
Replace `paths` with event's parameter because while adding node from firebase console, it's returning absolute url of path and using parameters are the best way to handle such situations.