### PR TITLE
Fixes for delete-unused-accounts-cron example

### DIFF
--- a/delete-unused-accounts-cron/functions/index.js
+++ b/delete-unused-accounts-cron/functions/index.js
@@ -46,7 +46,7 @@ exports.accountcleanup = functions.https.onRequest((req, res) => {
   getUsers().then(users => {
     // Find users that have not signed in in the last 30 days.
     const inactiveUsers = users.filter(
-        user => parseInt(user.lastLoginAt, 10) > Date.now() - 30 * 24 * 60 * 60 * 1000);
+        user => parseInt(user.lastLoginAt, 10) < Date.now() - 30 * 24 * 60 * 60 * 1000);
 
     // Use a pool so that we delete maximum `MAX_CONCURRENT` users in parallel.
     const promisePool = new PromisePool(() => {

--- a/delete-unused-accounts-cron/functions/index.js
+++ b/delete-unused-accounts-cron/functions/index.js
@@ -107,7 +107,8 @@ function getAccessToken(accessToken) {
 
   const options = {
     uri: 'http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token',
-    header: {'Metadata-Flavor': 'Google'}
+    headers: {'Metadata-Flavor': 'Google'},
+    json: true
   };
 
   return rp(options).then(resp => resp.access_token);

--- a/delete-unused-accounts-cron/functions/index.js
+++ b/delete-unused-accounts-cron/functions/index.js
@@ -54,10 +54,10 @@ exports.accountcleanup = functions.https.onRequest((req, res) => {
         const userToDelete = inactiveUsers.pop();
 
         // Delete the inactive user.
-        return admin.auth().deleteUser(userToDelete.uid).then(() => {
-          console.log('Deleted user account', userToDelete.uid, 'because of inactivity');
+        return admin.auth().deleteUser(userToDelete.localId).then(() => {
+          console.log('Deleted user account', userToDelete.localId, 'because of inactivity');
         }).catch(error => {
-          console.error('Deletion of inactive user account', userToDelete.uid, 'failed:', error);
+          console.error('Deletion of inactive user account', userToDelete.localId, 'failed:', error);
         });
       }
     }, MAX_CONCURRENT);

--- a/delete-unused-accounts-cron/functions/package.json
+++ b/delete-unused-accounts-cron/functions/package.json
@@ -5,10 +5,8 @@
     "es6-promise-pool": "^2.4.4",
     "firebase-admin": "^4.1.1",
     "firebase-functions": "^0.5.1",
-    "googleapis": "^16.1.0",
     "request": "^2.79.0",
     "request-promise": "^4.1.1",
-    "request-promise-native": "^1.0.3",
     "secure-compare": "^3.0.1"
   }
 }


### PR DESCRIPTION
This pull request contains fixes needed to get the delete-unused-accounts-cron example working for me.

The [CONTRIBUTING](https://github.com/firebase/functions-samples/blob/master/CONTRIBUTING.md#submitting-a-pull-request) guide mentions running gulp build and tests before submitting a PR, but they don't seem to exist for this repo? Or I couldn't find them anyway, so I did manual testing following the setup instructions in the [README](https://github.com/firebase/functions-samples/blob/master/delete-unused-accounts-cron/README.md) file, namely:

- Create a Firebase Project using the [Firebase Developer Console](https://console.firebase.google.com)
- Download this sample e.g. `git clone https://github.com/firebase/functions-samples`
- Enter the sample directory `cd functions-samples/delete-unused-accounts-cron`
- Setup the sample with your project `firebase use --add` and follow the instructions.
- Install node dependencies of your Functions `cd functions; npm install; cd -`
- Add cron.key env var with `firebase functions:config:set cron.key="YOUR-KEY"`
- Deploy your project using `firebase deploy`.

However, instead of using a third-party cron service to trigger the function, I just ran `curl` from my laptop like so:

```
 curl https://us-central1-<PROJECT-ID>.cloudfunctions.net/accountcleanup?key=<YOUR-KEY>
 ```

During testing, I also reduced the inactive users interval from 30 days to 10 minutes to make it easier to verify that inactive user accounts get deleted.

See individual commit messages for more info on each change.