### PR TITLE
Stripe - Update Readme to Fix project configuration

### DIFF
--- a/stripe/README.md
+++ b/stripe/README.md
@@ -18,7 +18,8 @@ To test this integration:
  - Create a Firebase Project using the [Firebase Developer Console](https://console.firebase.google.com)
  - Enable billing on your project by switching to the Blaze or Flame plan. See [pricing](https://firebase.google.com/pricing/) for more details. This is required to be able to do requests to non-Google services.
  - [Enable Google sign on your Firebase project ](https://console.firebase.google.com/project/_/authentication/providers)
- - Configure this sample to use your project using `firebase --use add` and select your project.
+ - Install [Firebase CLI Tools](https://github.com/firebase/firebase-tools) if you have not already and log in `firebase login`
+ - Configure this sample to use your project using `firebase use --add` and select your project.
  - Install dependencies locally by running: `cd functions; npm install; cd -`
  - [Add your Stripe API Secret Key](https://dashboard.stripe.com/account/apikeys) to firebase config:
      ```bash

--- a/stripe/README.md
+++ b/stripe/README.md
@@ -18,7 +18,7 @@ To test this integration:
  - Create a Firebase Project using the [Firebase Developer Console](https://console.firebase.google.com)
  - Enable billing on your project by switching to the Blaze or Flame plan. See [pricing](https://firebase.google.com/pricing/) for more details. This is required to be able to do requests to non-Google services.
  - [Enable Google sign on your Firebase project ](https://console.firebase.google.com/project/_/authentication/providers)
- - Install [Firebase CLI Tools](https://github.com/firebase/firebase-tools) if you have not already and log in `firebase login`
+ - Install [Firebase CLI Tools](https://github.com/firebase/firebase-tools) if you have not already and log in with `firebase login`.
  - Configure this sample to use your project using `firebase use --add` and select your project.
  - Install dependencies locally by running: `cd functions; npm install; cd -`
  - [Add your Stripe API Secret Key](https://dashboard.stripe.com/account/apikeys) to firebase config:


### PR DESCRIPTION
There was no mention to make sure the developer had Firebase CLI Tools installed, and the command to configure the sample to use the project was incorrect.
`firebase --use add` --> `firebase use --add`