### PR TITLE
Update quickstars/email-users

### DIFF
--- a/quickstarts/email-users/firebase.json
+++ b/quickstarts/email-users/firebase.json
@@ -1,5 +1,5 @@
 {
   "hosting": {
-    "public": "public"
+    "public": "./public"
   }
 }

--- a/quickstarts/email-users/functions/package.json
+++ b/quickstarts/email-users/functions/package.json
@@ -4,6 +4,6 @@
   "dependencies": {
     "firebase-admin": "^4.1.1",
     "firebase-functions": "^0.5.1",
-    "nodemailer": "^2.4.1"
+    "nodemailer": "^4.0.1"
   }
 }


### PR DESCRIPTION
The last version(2.4.1) of nodemailer is officially deprecated, so I added 4.0.1.

<img width="902" alt="screen shot 2017-07-23 at 12 03 54" src="https://user-images.githubusercontent.com/8782666/28498108-6fe3a028-6f9f-11e7-9c6b-d046f1e25653.png">

Did this to ensure the functionality. Furthermore, tried to run the project, but didn't work until I altered the firebase.json file by changing the path from "public" to "./public". Otherwise, the hosting website wasn't found.