### PR TITLE
Use built-in NodeJS crypto package.

### DIFF
--- a/github-to-slack/functions/package.json
+++ b/github-to-slack/functions/package.json
@@ -2,7 +2,6 @@
   "name": "github-to-slack-functions",
   "description": "Firebase Functions that posts new GitHub commits to a Slack channel.",
   "dependencies": {
-    "crypto": "0.0.3",
     "firebase-admin": "^4.1.2",
     "firebase-functions": "^0.5.1",
     "request": "^2.80.0",

--- a/instagram-auth/functions/package.json
+++ b/instagram-auth/functions/package.json
@@ -3,7 +3,6 @@
   "description": "Authenticate with Instagram Firebase Functions sample",
   "dependencies": {
     "cookie-parser": "^1.4.3",
-    "crypto": "0.0.3",
     "firebase-admin": "^4.1.1",
     "firebase-functions": "^0.5.1",
     "request": "^2.74.0",

--- a/linkedin-auth/functions/package.json
+++ b/linkedin-auth/functions/package.json
@@ -3,7 +3,6 @@
   "description": "Authenticate with LinkedIn Firebase Functions sample",
   "dependencies": {
     "cookie-parser": "^1.4.3",
-    "crypto": "0.0.3",
     "firebase-admin": "^4.1.1",
     "firebase-functions": "^0.5.1",
     "node-linkedin": "^0.5.4"


### PR DESCRIPTION
The NPM crypto package is not what people think it is. It's at version 0.0.3, has no license, and hasn't been touched in six years. Instead it's almost certainly better to use the built-in NodeJS crypto package (https://nodejs.org/api/crypto.html), which is probably what was originally intended.

#204 