### PR TITLE
Improve `developer_motivator` docs 

### DIFF
--- a/developer-motivator/README.md
+++ b/developer-motivator/README.md
@@ -22,7 +22,7 @@ The functions triggers every time a new user open your app the first time or rem
 To deploy and test the sample:
 
  - Create a Firebase project on the [Firebase Console](https://console.firebase.google.com)
- - In the Google Analytics for Firebase dashboard, in the `Events` tab, mark the `app_remove` event a conversion event by switching the toggle. The `first_open` event should already be marked as such.
+ - In the Firebase Console, under `Analytics`, in the `Events` tab, mark the `app_remove` event a conversion event by switching the toggle. The `first_open` event should already be marked as such.
  - Install the required dependencies by running `npm install` in the `functions` directory
  - Add this log to your android project:
 

--- a/developer-motivator/README.md
+++ b/developer-motivator/README.md
@@ -11,9 +11,11 @@ Sending the notification is done using the [Firebase Admin SDK](https://www.npmj
 
 The dependencies are listed in [functions/package.json](functions/package.json).
 
+
 ## Trigger rules
 
 The functions triggers every time a new user open your app the first time or remove your app from his device.
+
 
 ## Setup and test this sample section
 

--- a/developer-motivator/README.md
+++ b/developer-motivator/README.md
@@ -11,7 +11,6 @@ Sending the notification is done using the [Firebase Admin SDK](https://www.npmj
 
 The dependencies are listed in [functions/package.json](functions/package.json).
 
-
 ## Trigger rules
 
 The functions triggers every time a new user open your app the first time or remove your app from his device.
@@ -21,18 +20,19 @@ The functions triggers every time a new user open your app the first time or rem
 To deploy and test the sample:
 
  - Create a Firebase project on the [Firebase Console](https://console.firebase.google.com)
+ - In the Google Analytics for Firebase dashboard, in the `Events` tab, mark the `app_remove` event a conversion event by switching the toggle. The `first_open` event should already be marked as such.
  - Install the required dependencies by running `npm install` in the `functions` directory
  - Add this log to your android project:
 
     ```bash
     Log.d("Firebase", "token "+ FirebaseInstanceId.getInstance().getToken());
     ```
- - Run your app on your device and copy the device token from the android logcat  
+ - Run your app on your device and copy the device token from the android logcat
  - Set the `dev_motivator.device_token` Google Cloud environment variables. For this use:
 
     ```bash
-    firebase functions:config:set dev_motivator.device_token="your_developer_device_token" 
+    firebase functions:config:set dev_motivator.device_token="your_developer_device_token"
     ```
  - Deploy your project's code using `firebase deploy`
  - You'll now get a notification on your mobile when a user opens your app for the first tie and when they uninstall your app.
- 
+

--- a/developer-motivator/functions/index.js
+++ b/developer-motivator/functions/index.js
@@ -39,6 +39,8 @@ exports.appinstalled = functions.analytics.event('first_open').onLog(event => {
 
 /**
  * Triggers when the app is removed from the user device and sends a notification to your developer device.
+ * NOTE: for this trigger to  work, you must mark the `app_remove` event as a conversion event in Firebase's
+ * Analytics dashboard.
  *
  * The device model name, the city and the country of the user are sent in the notification message
  */


### PR DESCRIPTION
Note clearly in documentation and comments for the `developer_motivator` sample that the `app_remove` event must be manually marked as a conversion event before the sample works as intended.