### PR TITLE
Thumbnail errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 **/.firebaserc
 */npm-debug.log
 *~
+service-account-credentials.json

--- a/generate-thumbnail/functions/index.js
+++ b/generate-thumbnail/functions/index.js
@@ -78,7 +78,7 @@ exports.generateThumbnail = functions.storage.object().onChange(event => {
   }).then(() => {
     console.log('The file has been downloaded to', tempLocalFile);
     // Generate a thumbnail using ImageMagick.
-    return spawn('convert', [tempLocalFile, '-thumbnail', `${THUMB_MAX_WIDTH}x${THUMB_MAX_HEIGHT}>`, tempLocalThumbFile]);
+    return spawn('convert', [tempLocalFile, '-thumbnail', `${THUMB_MAX_WIDTH}x${THUMB_MAX_HEIGHT}>`, tempLocalThumbFile], {capture: ['stdout', 'stderr']});
   }).then(() => {
     console.log('Thumbnail created at', tempLocalThumbFile);
     // Uploading the Thumbnail.


### PR DESCRIPTION
To help better diagnose customer issues with the thumbnailer sample, I've added stdout/stderr capturing to the spawn command.

When testing, I noticed that my credentials were left as dirty files. Added them to the gitignore so nobody can accidentally commit a certificate file.