### PR TITLE
Updates dependencies in Uppercase Quickstart

### DIFF
--- a/quickstarts/uppercase/functions/package.json
+++ b/quickstarts/uppercase/functions/package.json
@@ -2,8 +2,8 @@
   "name": "uppercase-quickstart-functions",
   "description": "Uppercaser Firebase Functions Quickstart sample",
   "dependencies": {
-    "firebase-admin": "^4.1.1",
-    "firebase-functions": "^0.5.1"
+    "firebase-admin": "^5.5.1",
+    "firebase-functions": "^0.7.3"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
The dependencies in the Uppercase Quickstart are very out of date.  This updates them.

Note this PR should not be merged until https://github.com/firebase/functions-samples/issues/286 is fixed.