### PR TITLE
Fix for Typescript build script error

### DIFF
--- a/typescript-getting-started/functions/package.json
+++ b/typescript-getting-started/functions/package.json
@@ -11,7 +11,7 @@
     "typescript": "^2.6.1"
   },
   "scripts": {
-    "build": "./node_modules/.bin/tslint -p tslint.json && ./node_modules/.bin/tsc",
+    "build": "tslint -p tslint.json && tsc",
     "serve": "npm run build && firebase serve --only functions",
     "shell": "npm run build && firebase experimental:functions:shell",
     "start": "npm run shell",


### PR DESCRIPTION
Leaving the explicit paths in, I get this error:
```
$ npm run build

> functions@ build C:\Users\Nella\Documents\GitHub\dutchess-church\functions
> tslint -p tslint.json && ./node_modules/.bin/tsc

'.' is not recognized as an internal or external command,
operable program or batch file.
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! functions@ build: `tslint -p tslint.json && ./node_modules/.bin/tsc`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the functions@ build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\Nella\AppData\Roaming\npm-cache\_logs\2017-12-10T01_49_04_598Z-debug.log
```

Here is the debug log:
```
0 info it worked if it ends with ok
1 verbose cli [ 'C:\\Program Files\\nodejs\\node.exe',
1 verbose cli   'C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js',
1 verbose cli   'run',
1 verbose cli   'build' ]
2 info using npm@5.5.1
3 info using node@v8.9.3
4 verbose run-script [ 'prebuild', 'build', 'postbuild' ]
5 info lifecycle functions@~prebuild: functions@
6 info lifecycle functions@~build: functions@
7 verbose lifecycle functions@~build: unsafe-perm in lifecycle true
8 verbose lifecycle functions@~build: PATH: C:\Program Files\nodejs\node_modules\npm\bin\node-gyp-bin;C:\Users\Nella\Documents\GitHub\dutchess-church\functions\node_modules\.bin;C:\Program Files\Git\mingw64\bin;C:\Program Files\Git\usr\bin;C:\Users\Nella\bin;C:\Program Files\ImageMagick-7.0.7-Q16;C:\Python27;C:\Python27\Scripts;C:\ProgramData\Oracle\Java\javapath;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0;C:\Program Files (x86)\NVIDIA Corporation\PhysX\Common;C:\WINDOWS\system32;C:\WINDOWS;C:\WINDOWS\System32\Wbem;C:\WINDOWS\System32\WindowsPowerShell\v1.0;C:\Program Files (x86)\PuTTY;C:\Program Files (x86)\Windows Kits\8.1\Windows Performance Toolkit;C:\Program Files (x86)\Yarn\bin;C:\Program Files\nodejs;C:\Ruby23\bin;C:\Users\Nella\AppData\Local\Microsoft\WindowsApps;C:\Users\Nella\AppData\Local\GitHubDesktop\bin;C:\Program Files\Microsoft VS Code Insiders\bin;C:\Users\Nella\AppData\Local\Microsoft\WindowsApps;C:\Program Files\Microsoft VS Code\bin;C:\Users\Nella\AppData\Local\Yarn\bin;C:\Users\Nella\AppData\Roaming\npm
9 verbose lifecycle functions@~build: CWD: C:\Users\Nella\Documents\GitHub\dutchess-church\functions
10 silly lifecycle functions@~build: Args: [ '/d /s /c',
10 silly lifecycle   'tslint -p tslint.json && ./node_modules/.bin/tsc' ]
11 silly lifecycle functions@~build: Returned: code: 1  signal: null
12 info lifecycle functions@~build: Failed to exec build script
13 verbose stack Error: functions@ build: `tslint -p tslint.json && ./node_modules/.bin/tsc`
13 verbose stack Exit status 1
13 verbose stack     at EventEmitter.<anonymous> (C:\Program Files\nodejs\node_modules\npm\node_modules\npm-lifecycle\index.js:280:16)
13 verbose stack     at emitTwo (events.js:126:13)
13 verbose stack     at EventEmitter.emit (events.js:214:7)
13 verbose stack     at ChildProcess.<anonymous> (C:\Program Files\nodejs\node_modules\npm\node_modules\npm-lifecycle\lib\spawn.js:55:14)
13 verbose stack     at emitTwo (events.js:126:13)
13 verbose stack     at ChildProcess.emit (events.js:214:7)
13 verbose stack     at maybeClose (internal/child_process.js:925:16)
13 verbose stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:209:5)
14 verbose pkgid functions@
15 verbose cwd C:\Users\Nella\Documents\GitHub\dutchess-church\functions
16 verbose Windows_NT 10.0.17025
17 verbose argv "C:\\Program Files\\nodejs\\node.exe" "C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js" "run" "build"
18 verbose node v8.9.3
19 verbose npm  v5.5.1
20 error code ELIFECYCLE
21 error errno 1
22 error functions@ build: `tslint -p tslint.json && ./node_modules/.bin/tsc`
22 error Exit status 1
23 error Failed at the functions@ build script.
23 error This is probably not a problem with npm. There is likely additional logging output above.
24 verbose exit [ 1, true ]
```

Removing the explicit paths from the script makes it run just fine. I thought when things were run as an npm script, you didn't need to give explicit paths. I'm in Windows, which probably matters here.