### PR TITLE
Remove duplicate font stylesheet import

### DIFF
--- a/authorized-https-endpoint/public/index.html
+++ b/authorized-https-endpoint/public/index.html
@@ -21,7 +21,6 @@
 
   <!-- Material Design Lite -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
   <link rel="stylesheet" href="https://code.getmdl.io/1.1.3/material.blue_grey-orange.min.css">
   <script defer src="https://code.getmdl.io/1.1.3/material.min.js"></script>
 


### PR DESCRIPTION
Remove duplicated line to import stylesheet for "Material Icon" fonts