### PR TITLE
fix tslint path to project config

### DIFF
--- a/typescript-getting-started/functions/package.json
+++ b/typescript-getting-started/functions/package.json
@@ -11,7 +11,7 @@
     "typescript": "^2.6.1"
   },
   "scripts": {
-    "build": "./node_modules/.bin/tslint -p tslint.json && ./node_modules/.bin/tsc",
+    "build": "./node_modules/.bin/tslint --project tsconfig.json && ./node_modules/.bin/tsc",
     "serve": "npm run build && firebase serve --only functions",
     "shell": "npm run build && firebase experimental:functions:shell",
     "start": "npm run shell",


### PR DESCRIPTION
`-p` (or the long version `--project`) was incorrectly referencing the linting configuration in `tslint.json`. Fixing this to reference the `tsconfig.json` file to enable rules that work with the type checker.

Using the long version `--project` as it is more readable