### PR TITLE
Add scripts to package.json that now come with `firebase init`, incl linting

### DIFF
--- a/assistant-say-number/functions/package.json
+++ b/assistant-say-number/functions/package.json
@@ -5,5 +5,17 @@
     "actions-on-google": "^1.0.7",
     "firebase-admin": "^4.0.5",
     "firebase-functions": "^0.5.1"
+  },
+  "devDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-plugin-promise": "^3.6.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
   }
 }

--- a/authenticated-json-api/functions/package.json
+++ b/authenticated-json-api/functions/package.json
@@ -7,5 +7,17 @@
     "firebase-admin": "~4.1.2",
     "firebase-functions": "^0.5"
   },
-  "private": true
+  "private": true,
+  "devDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-plugin-promise": "^3.6.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
+  }
 }

--- a/authorized-https-endpoint/functions/package.json
+++ b/authorized-https-endpoint/functions/package.json
@@ -7,5 +7,17 @@
     "express": "^4.14.1",
     "firebase-admin": "^5.6.0",
     "firebase-functions": "^0.8.0"
+  },
+  "devDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-plugin-promise": "^3.6.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
   }
 }

--- a/bigquery-import/functions/package.json
+++ b/bigquery-import/functions/package.json
@@ -5,5 +5,17 @@
     "@google-cloud/bigquery": "^0.6.0",
     "firebase-admin": "^4.1.1",
     "firebase-functions": "^0.5.1"
+  },
+  "devDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-plugin-promise": "^3.6.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
   }
 }

--- a/child-count/functions/package.json
+++ b/child-count/functions/package.json
@@ -4,5 +4,17 @@
   "dependencies": {
     "firebase-admin": "^4.1.1",
     "firebase-functions": "^0.5.1"
+  },
+  "devDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-plugin-promise": "^3.6.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
   }
 }

--- a/convert-images/functions/package.json
+++ b/convert-images/functions/package.json
@@ -8,5 +8,17 @@
     "firebase-functions": "^0.5.1",
     "mkdirp": "^0.5.1",
     "mkdirp-promise": "^4.0.0"
+  },
+  "devDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-plugin-promise": "^3.6.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
   }
 }

--- a/coupon-on-purchase/functions/package.json
+++ b/coupon-on-purchase/functions/package.json
@@ -4,5 +4,17 @@
   "dependencies": {
     "firebase-admin": "^4.1.2",
     "firebase-functions": "^0.5.1"
+  },
+  "devDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-plugin-promise": "^3.6.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
   }
 }

--- a/crashlytics-integration/email-notifier/functions/package.json
+++ b/crashlytics-integration/email-notifier/functions/package.json
@@ -6,5 +6,17 @@
     "firebase-admin": "^5.4.2",
     "firebase-functions": "^0.7.2"
   },
-  "private": true
+  "private": true,
+  "devDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-plugin-promise": "^3.6.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
+  }
 }

--- a/crashlytics-integration/jira-issue/functions/package.json
+++ b/crashlytics-integration/jira-issue/functions/package.json
@@ -7,5 +7,17 @@
     "request": "^2.81.0",
     "request-promise": "^4.2.1"
   },
-  "private": true
+  "private": true,
+  "devDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-plugin-promise": "^3.6.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
+  }
 }

--- a/crashlytics-integration/slack-notifier/functions/package.json
+++ b/crashlytics-integration/slack-notifier/functions/package.json
@@ -7,5 +7,17 @@
     "request": "^2.81.0",
     "request-promise": "^4.2.1"
   },
-  "private": true
+  "private": true,
+  "devDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-plugin-promise": "^3.6.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
+  }
 }

--- a/delete-unused-accounts-cron/functions/package.json
+++ b/delete-unused-accounts-cron/functions/package.json
@@ -8,5 +8,17 @@
     "request": "^2.79.0",
     "request-promise": "^4.1.1",
     "secure-compare": "^3.0.1"
+  },
+  "devDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-plugin-promise": "^3.6.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
   }
 }

--- a/developer-motivator/functions/package.json
+++ b/developer-motivator/functions/package.json
@@ -4,5 +4,17 @@
   "dependencies": {
     "firebase-admin": "^4.1.2",
     "firebase-functions": "^0.5.1"
+  },
+  "devDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-plugin-promise": "^3.6.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
   }
 }

--- a/email-confirmation/functions/package.json
+++ b/email-confirmation/functions/package.json
@@ -5,5 +5,17 @@
     "nodemailer": "^2.4.1",
     "firebase-admin": "^4.1.1",
     "firebase-functions": "^0.5.1"
+  },
+  "devDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-plugin-promise": "^3.6.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
   }
 }

--- a/es2017-transpile/functions/package.json
+++ b/es2017-transpile/functions/package.json
@@ -10,9 +10,12 @@
     "babel-cli": "^6.26.0",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.6.1",
-    "babel-plugin-transform-object-rest-spread": "^6.26.0"
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
+    "eslint": "^4.13.1",
+    "eslint-plugin-promise": "^3.6.0"
   },
   "scripts": {
-    "prepare": "babel ./*.es7 --retain-lines -d ./"
+    "prepare": "babel ./*.es7 --retain-lines -d ./",
+    "lint": "./node_modules/.bin/eslint ."
   }
 }

--- a/exif-images/functions/package.json
+++ b/exif-images/functions/package.json
@@ -6,5 +6,17 @@
     "child-process-promise": "^2.2.0",
     "firebase-admin": "^4.1.1",
     "firebase-functions": "^0.5.1"
+  },
+  "devDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-plugin-promise": "^3.6.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
   }
 }

--- a/fcm-notifications/functions/package.json
+++ b/fcm-notifications/functions/package.json
@@ -4,5 +4,17 @@
   "dependencies": {
     "firebase-admin": "^4.1.2",
     "firebase-functions": "^0.5.1"
+  },
+  "devDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-plugin-promise": "^3.6.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
   }
 }

--- a/ffmpeg-convert-audio/functions/package.json
+++ b/ffmpeg-convert-audio/functions/package.json
@@ -8,5 +8,17 @@
     "firebase-admin": "^4.1.1",
     "firebase-functions": "^0.5.1",
     "fluent-ffmpeg": "^2.1.2"
+  },
+  "devDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-plugin-promise": "^3.6.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
   }
 }

--- a/fulltext-search-firestore/functions/package.json
+++ b/fulltext-search-firestore/functions/package.json
@@ -8,5 +8,17 @@
     "firebase-admin": "^5.0.0",
     "firebase-functions": "^0.7.0"
   },
-  "private": true
+  "private": true,
+  "devDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-plugin-promise": "^3.6.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
+  }
 }

--- a/fulltext-search/functions/package.json
+++ b/fulltext-search/functions/package.json
@@ -5,5 +5,17 @@
     "firebase-admin": "^4.1.1",
     "firebase-functions": "^0.5.1",
     "algoliasearch": "^3.10.2"
+  },
+  "devDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-plugin-promise": "^3.6.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
   }
 }

--- a/generate-thumbnail/functions/package.json
+++ b/generate-thumbnail/functions/package.json
@@ -8,5 +8,17 @@
     "firebase-functions": "^0.5.1",
     "mkdirp": "^0.5.1",
     "mkdirp-promise": "^4.0.0"
+  },
+  "devDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-plugin-promise": "^3.6.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
   }
 }

--- a/github-to-slack/functions/package.json
+++ b/github-to-slack/functions/package.json
@@ -7,5 +7,17 @@
     "request": "^2.80.0",
     "request-promise": "^4.1.1",
     "secure-compare": "^3.0.1"
+  },
+  "devDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-plugin-promise": "^3.6.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
   }
 }

--- a/google-sheet-sync/functions/package.json
+++ b/google-sheet-sync/functions/package.json
@@ -6,5 +6,17 @@
     "firebase-functions": "^0.5.6",
     "google-auth-library": "^0.10.0",
     "googleapis": "^18.0.0"
+  },
+  "devDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-plugin-promise": "^3.6.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
   }
 }

--- a/image-maker/functions/package.json
+++ b/image-maker/functions/package.json
@@ -7,5 +7,17 @@
     "firebase-admin": "4.2.1",
     "firebase-functions": "0.5.6",
     "lodash": "4.17.4"
+  },
+  "devDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-plugin-promise": "^3.6.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
   }
 }

--- a/image-sharp/functions/package.json
+++ b/image-sharp/functions/package.json
@@ -6,5 +6,17 @@
     "firebase-admin": "^4.1.1",
     "firebase-functions": "^0.5.1",
     "sharp": "^0.18.1"
+  },
+  "devDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-plugin-promise": "^3.6.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
   }
 }

--- a/instagram-auth/functions/package.json
+++ b/instagram-auth/functions/package.json
@@ -8,5 +8,17 @@
     "request": "^2.74.0",
     "request-promise-native": "^1.0.3",
     "simple-oauth2": "^1.0.0"
+  },
+  "devDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-plugin-promise": "^3.6.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
   }
 }

--- a/isomorphic-react-app/functions/firebase-database.js
+++ b/isomorphic-react-app/functions/firebase-database.js
@@ -37,17 +37,15 @@ const getAllEmployees = () => {
 // Get and return an employee by their id number
 // also fetch all of the employee's direct reports (if any)
 const getEmployeeById = employeeId => {
+  let employee;
   return firebase.database().ref(`/employees/${employeeId}`).once('value').then(snap => {
-    const promises = [];
-    const snapshot = snap.val();
-    if (snapshot.reports) {
-      Object.keys(snapshot.reports).forEach(userId => {
-        promises.push(firebase.database().ref(`/employees/${userId}`).once('value').then(snap => snap.val()));
-      });
-    }
-    return firebase.Promise.all(promises).then((resp) => {
-      return {currentEmployee: {employee: snapshot, reports: resp}};
-    });
+    employee = snap.val();
+    const reportIds = snapshot.reports || [];
+    const getReports = reportIds.map(userId => firebase.database().ref(`/employees/${userId}`).once('value'));
+    return Promise.all(getReports);
+  }).then(reportSnapshots => {
+    reports = reportSnapshots.map(snap => snap.val());
+    return {currentEmployee: employee, reports: reports};
   });
 };
 

--- a/isomorphic-react-app/functions/package.json
+++ b/isomorphic-react-app/functions/package.json
@@ -9,5 +9,17 @@
     "react": "15.5.4",
     "react-dom": "15.5.4",
     "request": "2.81.0"
+  },
+  "devDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-plugin-promise": "^3.6.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
   }
 }

--- a/lastmodified-tracking/functions/package.json
+++ b/lastmodified-tracking/functions/package.json
@@ -4,5 +4,17 @@
   "dependencies": {
     "firebase-admin": "^4.1.1",
     "firebase-functions": "^0.5.1"
+  },
+  "devDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-plugin-promise": "^3.6.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
   }
 }

--- a/limit-children/functions/package.json
+++ b/limit-children/functions/package.json
@@ -4,5 +4,17 @@
   "dependencies": {
     "firebase-admin": "^4.1.1",
     "firebase-functions": "^0.5.1"
+  },
+  "devDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-plugin-promise": "^3.6.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
   }
 }

--- a/line-auth/functions/package.json
+++ b/line-auth/functions/package.json
@@ -7,5 +7,17 @@
     "request-promise": "^4.1.1",
     "request": "^2.34"
   },
-  "private": true
+  "private": true,
+  "devDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-plugin-promise": "^3.6.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
+  }
 }

--- a/linkedin-auth/functions/package.json
+++ b/linkedin-auth/functions/package.json
@@ -6,5 +6,17 @@
     "firebase-admin": "^4.1.1",
     "firebase-functions": "^0.5.1",
     "node-linkedin": "^0.5.4"
+  },
+  "devDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-plugin-promise": "^3.6.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
   }
 }

--- a/message-translation/functions/package.json
+++ b/message-translation/functions/package.json
@@ -5,5 +5,17 @@
     "firebase-admin": "^4.1.1",
     "firebase-functions": "^0.5.1",
     "request-promise": "^2.0.0"
+  },
+  "devDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-plugin-promise": "^3.6.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
   }
 }

--- a/minimal-webhook/functions/package.json
+++ b/minimal-webhook/functions/package.json
@@ -5,5 +5,17 @@
     "firebase-admin": "^4.1.1",
     "firebase-functions": "^0.5.1",
     "request-promise": "^2.0.0"
+  },
+  "devDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-plugin-promise": "^3.6.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
   }
 }

--- a/moderate-images/functions/package.json
+++ b/moderate-images/functions/package.json
@@ -9,5 +9,17 @@
     "firebase-functions": "^0.5.1",
     "mkdirp": "^0.5.1",
     "mkdirp-promise": "^4.0.0"
+  },
+  "devDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-plugin-promise": "^3.6.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
   }
 }

--- a/nextjs-with-firebase-hosting/src/functions/package.json
+++ b/nextjs-with-firebase-hosting/src/functions/package.json
@@ -9,5 +9,17 @@
     "react": "^15.6.1",
     "react-dom": "^15.6.1"
   },
-  "private": true
+  "private": true,
+  "devDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-plugin-promise": "^3.6.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
+  }
 }

--- a/paypal/functions/package.json
+++ b/paypal/functions/package.json
@@ -9,8 +9,17 @@
   },
   "private": true,
   "devDependencies": {
-    "jshint": "^2.9.5",
-    "eslint": "^4.1.1",
-    "eslint-config-google": "^0.8.0"
+    "eslint": "^4.13.1",
+    "eslint-config-google": "^0.8.0",
+    "eslint-plugin-promise": "^3.6.0",
+    "jshint": "^2.9.5"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
   }
 }

--- a/presence-firestore/functions/package.json
+++ b/presence-firestore/functions/package.json
@@ -5,5 +5,17 @@
     "firebase-admin": "^5.0.0",
     "firebase-functions": "^0.7.0"
   },
-  "private": true
+  "private": true,
+  "devDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-plugin-promise": "^3.6.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
+  }
 }

--- a/quickstarts/big-ben/functions/package.json
+++ b/quickstarts/big-ben/functions/package.json
@@ -4,5 +4,17 @@
   "dependencies": {
     "firebase-admin": "^4.2.1",
     "firebase-functions": "^0.5.5"
+  },
+  "devDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-plugin-promise": "^3.6.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
   }
 }

--- a/quickstarts/email-users/functions/package.json
+++ b/quickstarts/email-users/functions/package.json
@@ -5,5 +5,17 @@
     "firebase-admin": "^4.1.1",
     "firebase-functions": "^0.5.1",
     "nodemailer": "^4.0.1"
+  },
+  "devDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-plugin-promise": "^3.6.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
   }
 }

--- a/quickstarts/pubsub-helloworld/functions/package.json
+++ b/quickstarts/pubsub-helloworld/functions/package.json
@@ -4,5 +4,17 @@
   "dependencies": {
     "firebase-admin": "^4.1.1",
     "firebase-functions": "^0.5.1"
+  },
+  "devDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-plugin-promise": "^3.6.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
   }
 }

--- a/quickstarts/thumbnails/functions/package.json
+++ b/quickstarts/thumbnails/functions/package.json
@@ -6,5 +6,17 @@
     "child-process-promise": "^2.2.0",
     "firebase-admin": "^4.1.1",
     "firebase-functions": "^0.5.1"
+  },
+  "devDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-plugin-promise": "^3.6.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
   }
 }

--- a/quickstarts/time-server/functions/package.json
+++ b/quickstarts/time-server/functions/package.json
@@ -6,5 +6,17 @@
     "firebase-admin": "^4.1.1",
     "firebase-functions": "^0.5.1",
     "moment": "^2.17.1"
+  },
+  "devDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-plugin-promise": "^3.6.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
   }
 }

--- a/quickstarts/uppercase-firestore/functions/package.json
+++ b/quickstarts/uppercase-firestore/functions/package.json
@@ -8,11 +8,19 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",
+    "eslint": "^4.13.1",
+    "eslint-plugin-promise": "^3.6.0",
     "mocha": "^3.2.0",
     "sinon": "^1.17.7"
   },
   "scripts": {
-    "test": "./node_modules/.bin/mocha --reporter spec"
+    "test": "./node_modules/.bin/mocha --reporter spec",
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
   },
   "private": true
 }

--- a/quickstarts/uppercase/functions/package.json
+++ b/quickstarts/uppercase/functions/package.json
@@ -12,6 +12,12 @@
     "sinon": "^4.1.3"
   },
   "scripts": {
-    "test": "./node_modules/.bin/mocha --reporter spec"
+    "test": "./node_modules/.bin/mocha --reporter spec",
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
   }
 }

--- a/spotify-auth/functions/package.json
+++ b/spotify-auth/functions/package.json
@@ -8,5 +8,17 @@
     "firebase-functions": "^0.5.5",
     "spotify-web-api-node": "^2.3.6"
   },
-  "private": true
+  "private": true,
+  "devDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-plugin-promise": "^3.6.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
+  }
 }

--- a/stripe/functions/package.json
+++ b/stripe/functions/package.json
@@ -6,5 +6,17 @@
     "firebase-admin": "^4.0.5",
     "firebase-functions": "^0.5.1",
     "stripe": "^4.15.0"
+  },
+  "devDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-plugin-promise": "^3.6.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
   }
 }

--- a/survey-app-update/functions/package.json
+++ b/survey-app-update/functions/package.json
@@ -5,5 +5,17 @@
     "nodemailer": "^2.4.1",
     "firebase-admin": "^4.1.1",
     "firebase-functions": "^0.5.1"
+  },
+  "devDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-plugin-promise": "^3.6.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
   }
 }

--- a/template-handlebars/functions/package.json
+++ b/template-handlebars/functions/package.json
@@ -9,5 +9,17 @@
     "firebase-admin": "^4.1.2",
     "firebase-functions": "^0.5.1",
     "handlebars": "^4.0.8"
+  },
+  "devDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-plugin-promise": "^3.6.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
   }
 }

--- a/text-moderation/functions/package.json
+++ b/text-moderation/functions/package.json
@@ -6,5 +6,17 @@
     "capitalize-sentence": "^0.1.2",
     "firebase-admin": "^4.1.1",
     "firebase-functions": "^0.5.1"
+  },
+  "devDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-plugin-promise": "^3.6.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
   }
 }

--- a/typescript-getting-started/functions/package.json
+++ b/typescript-getting-started/functions/package.json
@@ -11,7 +11,8 @@
     "typescript": "^2.6.1"
   },
   "scripts": {
-    "build": "./node_modules/.bin/tslint --project tsconfig.json && ./node_modules/.bin/tsc",
+    "lint": "./node_modules/.bin/tslint -p tsconfig.json",
+    "build": "./node_modules/.bin/tsc",
     "serve": "npm run build && firebase serve --only functions",
     "shell": "npm run build && firebase experimental:functions:shell",
     "start": "npm run shell",

--- a/typescript-getting-started/functions/tslint.json
+++ b/typescript-getting-started/functions/tslint.json
@@ -71,9 +71,6 @@
     // Expressions must always return a value. Avoids common errors like const myValue = functionReturningVoid();
     "no-void-expression": [true, "ignore-arrow-function-shorthand"],
 
-    // Makes sure result of typeof is compared to correct string values.
-    "typeof-compare": true,
-
     // Disallow duplicate imports in the same file.
     "no-duplicate-imports": true,
 

--- a/url-shortener/functions/package.json
+++ b/url-shortener/functions/package.json
@@ -5,5 +5,17 @@
     "firebase-admin": "^4.1.1",
     "firebase-functions": "^0.5.1",
     "request-promise": "^2.0.0"
+  },
+  "devDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-plugin-promise": "^3.6.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
   }
 }

--- a/username-password-auth/functions/package.json
+++ b/username-password-auth/functions/package.json
@@ -6,5 +6,17 @@
     "firebase-admin": "^4.1.1",
     "firebase-functions": "^0.5.1",
     "request": "^2.81.0"
+  },
+  "devDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-plugin-promise": "^3.6.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint .",
+    "serve": "firebase serve --only functions",
+    "shell": "firebase experimental:functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
   }
 }


### PR DESCRIPTION
This pull request is intentionally stacked so that robo-changes come before manual changes. I used git ls-files to find all package.json files and node to modify their JSON.

To test all files, I ran:

```bash
for i in $(git ls-files | grep 'functions/package.json'); do npm run lint --prefix $(dirname $i); done
```

The functions/ prefix was to detect cases where package.json was also used for firebase hosting.

Any NPM error meant that a `package.json` was missing the linter script (e.g. the code sample was added since I first robo-modified `package.json`s). Those were manually fixed. Any linter errors were also manually fixed.