### PR TITLE
Return a response so headers aren't set twice

### DIFF
--- a/quickstarts/time-server/functions/index.js
+++ b/quickstarts/time-server/functions/index.js
@@ -50,7 +50,7 @@ exports.date = functions.https.onRequest((req, res) => {
   // [START sendError]
   // Forbidding PUT requests.
   if (req.method === 'PUT') {
-    res.status(403).send('Forbidden!');
+    return res.status(403).send('Forbidden!');
   }
   // [END sendError]
 


### PR DESCRIPTION
Otherwise the function will continue running after the 'Forbidden' response is sent.