### PR TITLE
Updated url-shortener to use api key not from firebase variable

### DIFF
--- a/url-shortener/README.md
+++ b/url-shortener/README.md
@@ -30,3 +30,9 @@ This way, you can display a clean URL by fetching `/links/$linkId/short`.
             original: "https://my.super.long-link.com/api/user/profile/-jEHitne10395-k3593085",
             short: "https://goo.gl/EKDdza"
 ```
+
+## Deploy and test
+- Add your Firebase API key to firebase config:
+    ```bash
+    firebase functions:config:set firebaseApiKey=<YOUR FIREBASE API KEY>
+    ```

--- a/url-shortener/README.md
+++ b/url-shortener/README.md
@@ -2,6 +2,7 @@
 
 This template shows how to shorten URLs automatically as they are added.
 
+
 ## Functions Code
 
 See file [functions/index.js](functions/index.js) for the code.
@@ -9,6 +10,20 @@ See file [functions/index.js](functions/index.js) for the code.
 This uses the [Google URL Shortener API](https://developers.google.com/url-shortener/).
 
 The dependencies are listed in [functions/package.json](functions/package.json).
+
+## Setting up the sample
+
+ - Create a Firebase project using the [Firebase Console](https://console.firebase.google.com).
+ - [Enable the URL Shortener API](https://console.cloud.google.com/apis/library/urlshortener.googleapis.com/?project=_) on your Firebase Project.
+ - Set the sample ot use your Firebase project using `firebase use --add` and select your new Firebase project.
+ - Find your Firebase API Server key in the Firebase Console under **Project Settings > Cloud Messaging > Legacy server key**
+ - Add your Firebase API Server key to your Firebase project configuration:
+    ```bash
+    firebase functions:config:set keys.firebase_api=<YOUR FIREBASE API KEY>
+    ```
+ - Deploy the function using `firebase deploy`
+ - Manually add an object to the Realtime Database following the structure described below.
+
 
 ## Sample Database Structure
 
@@ -30,9 +45,3 @@ This way, you can display a clean URL by fetching `/links/$linkId/short`.
             original: "https://my.super.long-link.com/api/user/profile/-jEHitne10395-k3593085",
             short: "https://goo.gl/EKDdza"
 ```
-
-## Deploy and test
-- Add your Firebase API key to firebase config:
-    ```bash
-    firebase functions:config:set keys.firebase_api=<YOUR FIREBASE API KEY>
-    ```

--- a/url-shortener/README.md
+++ b/url-shortener/README.md
@@ -34,5 +34,5 @@ This way, you can display a clean URL by fetching `/links/$linkId/short`.
 ## Deploy and test
 - Add your Firebase API key to firebase config:
     ```bash
-    firebase functions:config:set firebaseApiKey=<YOUR FIREBASE API KEY>
+    firebase functions:config:set keys.firebase_api=<YOUR FIREBASE API KEY>
     ```

--- a/url-shortener/functions/index.js
+++ b/url-shortener/functions/index.js
@@ -33,7 +33,7 @@ exports.shortenUrl = functions.database.ref('/links/{linkID}').onWrite((event) =
 function createShortenerRequest(sourceUrl) {
   return {
     method: 'POST',
-    uri: `https://www.googleapis.com/urlshortener/v1/url?key=${functions.config().firebase.apiKey}`,
+    uri: `https://www.googleapis.com/urlshortener/v1/url?key=${functions.config().firebaseApiKey}`,
     body: {
       longUrl: sourceUrl,
     },

--- a/url-shortener/functions/index.js
+++ b/url-shortener/functions/index.js
@@ -33,7 +33,7 @@ exports.shortenUrl = functions.database.ref('/links/{linkID}').onWrite((event) =
 function createShortenerRequest(sourceUrl) {
   return {
     method: 'POST',
-    uri: `https://www.googleapis.com/urlshortener/v1/url?key=${functions.config().firebaseApiKey}`,
+    uri: `https://www.googleapis.com/urlshortener/v1/url?key=${functions.config().keys.firebase_api}`,
     body: {
       longUrl: sourceUrl,
     },


### PR DESCRIPTION
As of  [v3.17.5 of firebase-tools](https://github.com/firebase/firebase-tools/releases/tag/v3.17.5) `functions.config().firebase.apiKey` is no longer set therefore
a separate variable must be used or else RateLimit error may appear.