### PR TITLE
[google-sheet-sync] Fix return value error

### DIFF
--- a/google-sheet-sync/functions/index.js
+++ b/google-sheet-sync/functions/index.js
@@ -107,7 +107,7 @@ function appendPromise(requestWithoutAuth) {
           console.log(`The API returned an error: ${err}`);
           return reject(err);
         }
-        return resolve(response);
+        return resolve(response.data);
       });
     });
   });


### PR DESCRIPTION
Fix `Error serializing return value: TypeError: Converting circular structure to JSON` error from Cloud Functions logs. This is the continuation of pull request #341.