### PR TITLE
authorized-https-endpoint: getToken deprecated

### DIFF
--- a/authorized-https-endpoint/public/main.js
+++ b/authorized-https-endpoint/public/main.js
@@ -63,7 +63,7 @@ Demo.prototype.signOut = function() {
 
 // Does an authenticated request to a Firebase Functions endpoint using an Authorization header.
 Demo.prototype.startFunctionsRequest = function() {
-  firebase.auth().currentUser.getToken().then(function(token) {
+  firebase.auth().currentUser.getIdToken().then(function(token) {
     console.log('Sending request to', this.helloUserUrl, 'with ID token in Authorization header.');
     var req = new XMLHttpRequest();
     req.onload = function() {
@@ -81,7 +81,7 @@ Demo.prototype.startFunctionsRequest = function() {
 // Does an authenticated request to a Firebase Functions endpoint using a __session cookie.
 Demo.prototype.startFunctionsCookieRequest = function() {
   // Set the __session cookie.
-  firebase.auth().currentUser.getToken(true).then(function(token) {
+  firebase.auth().currentUser.getIdToken(true).then(function(token) {
     // set the __session cookie
     document.cookie = '__session=' + token + ';max-age=3600';
 


### PR DESCRIPTION
The `getToken` method has been deprecated and replaced with `getIdToken`.

I've verified that the example runs correctly locally after this change and now produces no warnings.