### PR TITLE
Typo Fix

### DIFF
--- a/fulltext-search-firestore/public/index.js
+++ b/fulltext-search-firestore/public/index.js
@@ -27,7 +27,7 @@ function unauthenticated_search(query) {
   // Perform an Algolia search:
   // https://www.algolia.com/doc/api-reference/api-methods/search/
   index
-    .seach({
+    .search({
       query
     })
     .then(function(responses) {


### PR DESCRIPTION
Just a small typo fix from 'seach' to 'search'