### PR TITLE
clear _session cookie on signOut

### DIFF
--- a/authorized-https-endpoint/public/main.js
+++ b/authorized-https-endpoint/public/main.js
@@ -59,6 +59,8 @@ Demo.prototype.signIn = function() {
 // Signs-out of Firebase.
 Demo.prototype.signOut = function() {
   firebase.auth().signOut();
+  // clear the __session cookie
+  document.cookie = '__session=';
 };
 
 // Does an authenticated request to a Firebase Functions endpoint using an Authorization header.


### PR DESCRIPTION
The API could still be accessed after sign out as the _session cookie still contains the user token.