### PR TITLE
Return firebase auth token after creating account in the linkedin-auth sample

### DIFF
--- a/linkedin-auth/functions/index.js
+++ b/linkedin-auth/functions/index.js
@@ -152,4 +152,5 @@ async function createFirebaseAccount(linkedinID, displayName, photoURL, email, a
   // Create a Firebase custom auth token.
   const token = await admin.auth().createCustomToken(uid);
   console.log('Created Custom token for UID "', uid, '" Token:', token);
+  return token;
 }


### PR DESCRIPTION
The firebase auth token from the `createFirebaseAccount` function in the linkedin-auth sample is not returned and causes the following client error: `Error in the token Function: undefined`. This PR fixes the function to return the token.