### PR TITLE
Update getToken from functinosOauthClient

### DIFF
--- a/google-sheet-sync/functions/index.js
+++ b/google-sheet-sync/functions/index.js
@@ -65,7 +65,7 @@ exports.oauthcallback = functions.https.onRequest(async (req, res) => {
   res.set('Cache-Control', 'private, max-age=0, s-maxage=0');
   const code = req.query.code;
   try {
-    const tokens = await functionsOauthClient.getToken(code);
+    const {tokens} = await functionsOauthClient.getToken(code);
     // Now tokens contains an access_token and an optional refresh_token. Save them.
     await admin.database().ref(DB_TOKEN_PATH).set(tokens);
     return res.status(200).send('App successfully configured with new Credentials. '


### PR DESCRIPTION
The sample code shows to set the results of `getToken` directly to the variable tokens however tokens is now a property of the response so you need to store the tokens object from within the response as google states here:

https://github.com/google/google-api-nodejs-client:
```
const {tokens} = await oauth2Client.getToken(code)
oauth2Client.setCredentials(tokens);
```