### PR TITLE
Fixed typo in Firestore example README

### DIFF
--- a/quickstarts/uppercase-firestore/functions/index.js
+++ b/quickstarts/uppercase-firestore/functions/index.js
@@ -36,7 +36,7 @@ exports.addMessage = functions.https.onRequest((req, res) => {
   // [START adminSdkAdd]
   // Push the new message into the Realtime Database using the Firebase Admin SDK.
   return admin.firestore().collection('messages').add({original: original}).then((writeResult) => {
-    // Send back a message that we've succesfully written the message
+    // Send back a message that we've successfully written the message
     return res.json({result: `Message with ID: ${writeResult.id} added.`});
   });
   // [END adminSdkAdd]


### PR DESCRIPTION
A trivial change to spell _successfully_ correctly.

Would be great if someone checked why build failed as documentation change should not have caused build failure.