### PR TITLE
Update signature check in github-to-slack function

### DIFF
--- a/github-to-slack/functions/index.js
+++ b/github-to-slack/functions/index.js
@@ -30,7 +30,7 @@ exports.githubWebhook = functions.https.onRequest(async (req, res) => {
 
   // TODO: Configure the `github.secret` Google Cloud environment variables.
   const hmac = crypto.createHmac(cipher, functions.config().github.secret)
-      .update(req.body)
+      .update(req.rawBody)
       .digest('hex');
   const expectedSignature = `${cipher}=${hmac}`;
 


### PR DESCRIPTION
req.body is a JSON object, not a string or buffer (as required by crypto's update method)
req.rawBody is a buffer, which works

fixes #533 