### PR TITLE
Modernize image moderation sample

### DIFF
--- a/moderate-images/README.md
+++ b/moderate-images/README.md
@@ -2,7 +2,6 @@
 
 This sample demonstrates how to automatically moderate offensive images uploaded to Firebase Storage. It uses The Google Cloud Vision API to detect if the image contains adult or violent content and if so uses ImageMagick to blur the image.
 
-
 ## Functions Code
 
 See file [functions/index.js](functions/index.js) for the moderation code.
@@ -12,11 +11,9 @@ The image blurring is performed using ImageMagick which is installed by default 
 
 The dependencies are listed in [functions/package.json](functions/package.json).
 
-
 ## Trigger rules
 
 The function triggers on upload of any file to your Firebase project's default Cloud Storage bucket.
-
 
 ## Setting up the sample
 
@@ -26,11 +23,10 @@ The function triggers on upload of any file to your Firebase project's default C
  1. You must have the Firebase CLI installed. If you don't have it install it with `npm install -g firebase-tools` and then configure it with `firebase login`.
  1. Configure the CLI locally by using `firebase use --add` and select your project in the list.
  1. Install dependencies locally by running: `cd functions; npm install; cd -`
- 
 
 ## Deploy and test
 
 To test the sample:
 
 1. Deploy your Cloud Functions using `firebase deploy`
-1. Go to the Firebase Console **Storage** tab and upload an image that contains adult or violent content. After a short time the image will be replaced by a blurred version of itself.
+1. Go to the Firebase Console **Storage** tab and upload an image that contains adult or violent content. After a short time, refresh the page. You'll see a new folder that contains a blurred version of your uploaded image.

--- a/moderate-images/functions/package.json
+++ b/moderate-images/functions/package.json
@@ -2,12 +2,12 @@
   "name": "moderate-image-function",
   "description": "Offensive Image blurring using Firebase Function",
   "dependencies": {
-    "@google-cloud/vision": "^0.5.0",
+    "@google-cloud/vision": "^1.1.4",
     "child-process-promise": "^2.2.0",
+    "firebase-admin": "^8.2.0",
+    "firebase-functions": "^3.2.0",
     "mkdirp": "^0.5.1",
-    "mkdirp-promise": "^4.0.0",
-    "firebase-admin": "~7.1.1",
-    "firebase-functions": "^2.2.1"
+    "mkdirp-promise": "^4.0.0"
   },
   "devDependencies": {
     "eslint": "^4.13.1",


### PR DESCRIPTION
Image moderation sample was using an outdated version of the Cloud Vision API and Firebase SDKs. I've updated them to use the latest versions.

In addition, since the function ran on every upload, sometimes a blurred image would trigger a re-blur, causing an infinite loop. I've changed the behavior of the sample to upload to a different folder so that it does not infinite loop.