### PR TITLE
Fix firebaseui links in stripe sample

### DIFF
--- a/stripe/public/index.html
+++ b/stripe/public/index.html
@@ -5,7 +5,7 @@
     <title>Cloud Functions for Firebase (Stripe example)</title>
     <script src="https://js.stripe.com/v2/"></script>
     <script src="https://unpkg.com/vue/dist/vue.js"></script>
-    <link rel="stylesheet" href="https://cdn.firebase.com/libs/firebaseui/4.4.0/firebaseui.css" />
+    <link rel="stylesheet" href="https://www.gstatic.com/firebasejs/ui/4.4.0/firebase-ui-auth.css" />
   </head>
   <body>
     <div class="container">
@@ -107,7 +107,7 @@
     <script src="/__/firebase/init.js"></script>
 
     <!-- Import Firebase UI -->
-    <script src="https://cdn.firebase.com/libs/firebaseui/4.4.0/firebaseui.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/ui/4.4.0/firebase-ui-auth.js"></script>
 
     <script>
       Stripe.setPublishableKey( /* TODO: add your stripe publishable key */ );


### PR DESCRIPTION
fixes #663 

The current spots where this sample looks for firebaseui:

* https://cdn.firebase.com/libs/firebaseui/4.4.0/firebaseui.css
* https://cdn.firebase.com/libs/firebaseui/4.4.0/firebaseui.js

No longer work, so I've switched to:

* https://www.gstatic.com/firebasejs/ui/4.4.0/firebase-ui-auth.css
* https://www.gstatic.com/firebasejs/ui/4.4.0/firebase-ui-auth.js

These are the recommended urls in the [firebaseui readme](https://github.com/firebase/firebaseui-web#option-1-cdn).
