### PR TITLE
Fix generate-thumbnail: swap out mkdirp-promise

### DIFF
--- a/generate-thumbnail/functions/index.js
+++ b/generate-thumbnail/functions/index.js
@@ -16,7 +16,6 @@
 'use strict';
 
 const functions = require('firebase-functions');
-const mkdirp = require('mkdirp');
 const admin = require('firebase-admin');
 admin.initializeApp();
 const spawn = require('child-process-promise').spawn;
@@ -36,85 +35,66 @@ const THUMB_PREFIX = 'thumb_';
  * After the thumbnail has been generated and uploaded to Cloud Storage,
  * we write the public URL to the Firebase Realtime Database.
  */
-exports.generateThumbnail = functions.storage
-  .object()
-  .onFinalize(async object => {
-    // File and directory paths.
-    const filePath = object.name;
-    const contentType = object.contentType; // This is the image MIME type
-    const fileDir = path.dirname(filePath);
-    const fileName = path.basename(filePath);
-    const thumbFilePath = path.normalize(
-      path.join(fileDir, `${THUMB_PREFIX}${fileName}`)
-    );
-    const tempLocalFile = path.join(os.tmpdir(), filePath);
-    const tempLocalDir = path.dirname(tempLocalFile);
-    const tempLocalThumbFile = path.join(os.tmpdir(), thumbFilePath);
+exports.generateThumbnail = functions.storage.object().onFinalize(async (object) => {
+  // File and directory paths.
+  const filePath = object.name;
+  const contentType = object.contentType; // This is the image MIME type
+  const fileDir = path.dirname(filePath);
+  const fileName = path.basename(filePath);
+  const thumbFilePath = path.normalize(path.join(fileDir, `${THUMB_PREFIX}${fileName}`));
+  const tempLocalFile = path.join(os.tmpdir(), filePath);
+  const tempLocalDir = path.dirname(tempLocalFile);
+  const tempLocalThumbFile = path.join(os.tmpdir(), thumbFilePath);
 
-    // Exit if this is triggered on a file that is not an image.
-    if (!contentType.startsWith('image/')) {
-      return console.log('This is not an image.');
-    }
+  // Exit if this is triggered on a file that is not an image.
+  if (!contentType.startsWith('image/')) {
+    return console.log('This is not an image.');
+  }
 
-    // Exit if the image is already a thumbnail.
-    if (fileName.startsWith(THUMB_PREFIX)) {
-      return console.log('Already a Thumbnail.');
-    }
+  // Exit if the image is already a thumbnail.
+  if (fileName.startsWith(THUMB_PREFIX)) {
+    return console.log('Already a Thumbnail.');
+  }
 
-    // Cloud Storage files.
-    const bucket = admin.storage().bucket(object.bucket);
-    const file = bucket.file(filePath);
-    const thumbFile = bucket.file(thumbFilePath);
-    const metadata = {
-      contentType: contentType
-      // To enable Client-side caching you can set the Cache-Control headers here. Uncomment below.
-      // 'Cache-Control': 'public,max-age=3600',
-    };
-
-    // Create the temp directory where the storage file will be downloaded.
-    await mkdirp(tempLocalDir);
-    // Download file from bucket.
-    await file.download({ destination: tempLocalFile });
-    console.log('The file has been downloaded to', tempLocalFile);
-    // Generate a thumbnail using ImageMagick.
-    await spawn(
-      'convert',
-      [
-        tempLocalFile,
-        '-thumbnail',
-        `${THUMB_MAX_WIDTH}x${THUMB_MAX_HEIGHT}>`,
-        tempLocalThumbFile
-      ],
-      { capture: ['stdout', 'stderr'] }
-    );
-    console.log('Thumbnail created at', tempLocalThumbFile);
-    // Uploading the Thumbnail.
-    await bucket.upload(tempLocalThumbFile, {
-      destination: thumbFilePath,
-      metadata: metadata
-    });
-    console.log('Thumbnail uploaded to Storage at', thumbFilePath);
-    // Once the image has been uploaded delete the local files to free up disk space.
-    fs.unlinkSync(tempLocalFile);
-    fs.unlinkSync(tempLocalThumbFile);
-    // Get the Signed URLs for the thumbnail and original image.
-    const config = {
-      action: 'read',
-      expires: '03-01-2500'
-    };
-    const results = await Promise.all([
-      thumbFile.getSignedUrl(config),
-      file.getSignedUrl(config)
-    ]);
-    console.log('Got Signed URLs.');
-    const thumbResult = results[0];
-    const originalResult = results[1];
-    const thumbFileUrl = thumbResult[0];
-    const fileUrl = originalResult[0];
-    // Add the URLs to the Database
-    await admin
-      .database()
-      .ref('images')
-      .push({ path: fileUrl, thumbnail: thumbFileUrl });
-    return console.log('Thumbnail URLs saved to database.');
-  });
+  // Cloud Storage files.
+  const bucket = admin.storage().bucket(object.bucket);
+  const file = bucket.file(filePath);
+  const thumbFile = bucket.file(thumbFilePath);
+  const metadata = {
+    contentType: contentType,
+    // To enable Client-side caching you can set the Cache-Control headers here. Uncomment below.
+    // 'Cache-Control': 'public,max-age=3600',
+  };
+  
+  // Create the temp directory where the storage file will be downloaded.
+  await mkdirp(tempLocalDir)
+  // Download file from bucket.
+  await file.download({destination: tempLocalFile});
+  console.log('The file has been downloaded to', tempLocalFile);
+  // Generate a thumbnail using ImageMagick.
+  await spawn('convert', [tempLocalFile, '-thumbnail', `${THUMB_MAX_WIDTH}x${THUMB_MAX_HEIGHT}>`, tempLocalThumbFile], {capture: ['stdout', 'stderr']});
+  console.log('Thumbnail created at', tempLocalThumbFile);
+  // Uploading the Thumbnail.
+  await bucket.upload(tempLocalThumbFile, {destination: thumbFilePath, metadata: metadata});
+  console.log('Thumbnail uploaded to Storage at', thumbFilePath);
+  // Once the image has been uploaded delete the local files to free up disk space.
+  fs.unlinkSync(tempLocalFile);
+  fs.unlinkSync(tempLocalThumbFile);
+  // Get the Signed URLs for the thumbnail and original image.
+  const config = {
+    action: 'read',
+    expires: '03-01-2500',
+  };
+  const results = await Promise.all([
+    thumbFile.getSignedUrl(config),
+    file.getSignedUrl(config),
+  ]);
+  console.log('Got Signed URLs.');
+  const thumbResult = results[0];
+  const originalResult = results[1];
+  const thumbFileUrl = thumbResult[0];
+  const fileUrl = originalResult[0];
+  // Add the URLs to the Database
+  await admin.database().ref('images').push({path: fileUrl, thumbnail: thumbFileUrl});
+  return console.log('Thumbnail URLs saved to database.');
+});

--- a/generate-thumbnail/functions/index.js
+++ b/generate-thumbnail/functions/index.js
@@ -16,7 +16,7 @@
 'use strict';
 
 const functions = require('firebase-functions');
-const mkdirp = require('mkdirp-promise');
+const mkdirp = require('mkdirp');
 const admin = require('firebase-admin');
 admin.initializeApp();
 const spawn = require('child-process-promise').spawn;
@@ -36,66 +36,85 @@ const THUMB_PREFIX = 'thumb_';
  * After the thumbnail has been generated and uploaded to Cloud Storage,
  * we write the public URL to the Firebase Realtime Database.
  */
-exports.generateThumbnail = functions.storage.object().onFinalize(async (object) => {
-  // File and directory paths.
-  const filePath = object.name;
-  const contentType = object.contentType; // This is the image MIME type
-  const fileDir = path.dirname(filePath);
-  const fileName = path.basename(filePath);
-  const thumbFilePath = path.normalize(path.join(fileDir, `${THUMB_PREFIX}${fileName}`));
-  const tempLocalFile = path.join(os.tmpdir(), filePath);
-  const tempLocalDir = path.dirname(tempLocalFile);
-  const tempLocalThumbFile = path.join(os.tmpdir(), thumbFilePath);
+exports.generateThumbnail = functions.storage
+  .object()
+  .onFinalize(async object => {
+    // File and directory paths.
+    const filePath = object.name;
+    const contentType = object.contentType; // This is the image MIME type
+    const fileDir = path.dirname(filePath);
+    const fileName = path.basename(filePath);
+    const thumbFilePath = path.normalize(
+      path.join(fileDir, `${THUMB_PREFIX}${fileName}`)
+    );
+    const tempLocalFile = path.join(os.tmpdir(), filePath);
+    const tempLocalDir = path.dirname(tempLocalFile);
+    const tempLocalThumbFile = path.join(os.tmpdir(), thumbFilePath);
 
-  // Exit if this is triggered on a file that is not an image.
-  if (!contentType.startsWith('image/')) {
-    return console.log('This is not an image.');
-  }
+    // Exit if this is triggered on a file that is not an image.
+    if (!contentType.startsWith('image/')) {
+      return console.log('This is not an image.');
+    }
 
-  // Exit if the image is already a thumbnail.
-  if (fileName.startsWith(THUMB_PREFIX)) {
-    return console.log('Already a Thumbnail.');
-  }
+    // Exit if the image is already a thumbnail.
+    if (fileName.startsWith(THUMB_PREFIX)) {
+      return console.log('Already a Thumbnail.');
+    }
 
-  // Cloud Storage files.
-  const bucket = admin.storage().bucket(object.bucket);
-  const file = bucket.file(filePath);
-  const thumbFile = bucket.file(thumbFilePath);
-  const metadata = {
-    contentType: contentType,
-    // To enable Client-side caching you can set the Cache-Control headers here. Uncomment below.
-    // 'Cache-Control': 'public,max-age=3600',
-  };
-  
-  // Create the temp directory where the storage file will be downloaded.
-  await mkdirp(tempLocalDir)
-  // Download file from bucket.
-  await file.download({destination: tempLocalFile});
-  console.log('The file has been downloaded to', tempLocalFile);
-  // Generate a thumbnail using ImageMagick.
-  await spawn('convert', [tempLocalFile, '-thumbnail', `${THUMB_MAX_WIDTH}x${THUMB_MAX_HEIGHT}>`, tempLocalThumbFile], {capture: ['stdout', 'stderr']});
-  console.log('Thumbnail created at', tempLocalThumbFile);
-  // Uploading the Thumbnail.
-  await bucket.upload(tempLocalThumbFile, {destination: thumbFilePath, metadata: metadata});
-  console.log('Thumbnail uploaded to Storage at', thumbFilePath);
-  // Once the image has been uploaded delete the local files to free up disk space.
-  fs.unlinkSync(tempLocalFile);
-  fs.unlinkSync(tempLocalThumbFile);
-  // Get the Signed URLs for the thumbnail and original image.
-  const config = {
-    action: 'read',
-    expires: '03-01-2500',
-  };
-  const results = await Promise.all([
-    thumbFile.getSignedUrl(config),
-    file.getSignedUrl(config),
-  ]);
-  console.log('Got Signed URLs.');
-  const thumbResult = results[0];
-  const originalResult = results[1];
-  const thumbFileUrl = thumbResult[0];
-  const fileUrl = originalResult[0];
-  // Add the URLs to the Database
-  await admin.database().ref('images').push({path: fileUrl, thumbnail: thumbFileUrl});
-  return console.log('Thumbnail URLs saved to database.');
-});
+    // Cloud Storage files.
+    const bucket = admin.storage().bucket(object.bucket);
+    const file = bucket.file(filePath);
+    const thumbFile = bucket.file(thumbFilePath);
+    const metadata = {
+      contentType: contentType
+      // To enable Client-side caching you can set the Cache-Control headers here. Uncomment below.
+      // 'Cache-Control': 'public,max-age=3600',
+    };
+
+    // Create the temp directory where the storage file will be downloaded.
+    await mkdirp(tempLocalDir);
+    // Download file from bucket.
+    await file.download({ destination: tempLocalFile });
+    console.log('The file has been downloaded to', tempLocalFile);
+    // Generate a thumbnail using ImageMagick.
+    await spawn(
+      'convert',
+      [
+        tempLocalFile,
+        '-thumbnail',
+        `${THUMB_MAX_WIDTH}x${THUMB_MAX_HEIGHT}>`,
+        tempLocalThumbFile
+      ],
+      { capture: ['stdout', 'stderr'] }
+    );
+    console.log('Thumbnail created at', tempLocalThumbFile);
+    // Uploading the Thumbnail.
+    await bucket.upload(tempLocalThumbFile, {
+      destination: thumbFilePath,
+      metadata: metadata
+    });
+    console.log('Thumbnail uploaded to Storage at', thumbFilePath);
+    // Once the image has been uploaded delete the local files to free up disk space.
+    fs.unlinkSync(tempLocalFile);
+    fs.unlinkSync(tempLocalThumbFile);
+    // Get the Signed URLs for the thumbnail and original image.
+    const config = {
+      action: 'read',
+      expires: '03-01-2500'
+    };
+    const results = await Promise.all([
+      thumbFile.getSignedUrl(config),
+      file.getSignedUrl(config)
+    ]);
+    console.log('Got Signed URLs.');
+    const thumbResult = results[0];
+    const originalResult = results[1];
+    const thumbFileUrl = thumbResult[0];
+    const fileUrl = originalResult[0];
+    // Add the URLs to the Database
+    await admin
+      .database()
+      .ref('images')
+      .push({ path: fileUrl, thumbnail: thumbFileUrl });
+    return console.log('Thumbnail URLs saved to database.');
+  });

--- a/generate-thumbnail/functions/index.js
+++ b/generate-thumbnail/functions/index.js
@@ -16,6 +16,7 @@
 'use strict';
 
 const functions = require('firebase-functions');
+const mkdirp = require('mkdirp');
 const admin = require('firebase-admin');
 admin.initializeApp();
 const spawn = require('child-process-promise').spawn;

--- a/generate-thumbnail/functions/package.json
+++ b/generate-thumbnail/functions/package.json
@@ -4,7 +4,6 @@
   "dependencies": {
     "child-process-promise": "^2.2.1",
     "mkdirp": "^1.0.3",
-    "mkdirp-promise": "^5.0.1",
     "firebase-admin": "~8.9.2",
     "firebase-functions": "^3.3.0"
   },


### PR DESCRIPTION
[mkdirp](https://www.npmjs.com/package/mkdirp) is now promise-based, and [mkdirp-promise](https://www.npmjs.com/package/mkdirp-promise) no longer works. mkdirp-promise caused this function to hang forever when it tried to create a local directory.