### PR TITLE
Fix npm build warning

### DIFF
--- a/nextjs-with-firebase-hosting/package.json
+++ b/nextjs-with-firebase-hosting/package.json
@@ -11,7 +11,7 @@
     "predeploy": "npm run build-all",
     "deploy": "firebase deploy",
     "build-all": "npm run build-next && npm run build-firebase",
-    "build-next": "cd \"src/app\" && npm install && npm build",
+    "build-next": "cd \"src/app\" && npm install && npm run build",
     "build-firebase": "cd \"src/functions\" && npm install"
   }
 }


### PR DESCRIPTION
This closes #690. I also do a quick search for `npm build` across the whole project, and this is the only usage.