### PR TITLE
[testlab-to-slack] Simplify Slack configuration

### DIFF
--- a/testlab-to-slack/README.md
+++ b/testlab-to-slack/README.md
@@ -8,22 +8,7 @@ this:
 
 ## Setting up the sample
 
-1.  [Create a Slack app](https://api.slack.com/slack-apps#creating_apps)
-1.  Visit Slack's [_Your Apps_](https://api.slack.com/apps) page, select your
-    app, and click _OAuth & Permissions_ on the left side of the page.
-
-    1. Under the _Scopes_ header, type in `chat:write:bot` and add the scope to
-       your app. Click _Save Changes_
-
-    1. Under the _OAuth Tokens & Redirect URLs_ header, click the _Install App_
-       button. Once you've installed the app to your Workspace and you're
-       returned to the page with _OAuth Tokens & Redirect URLs_, copy the _OAuth
-       Access Token_ that was automatically created when your app was installed.
-       You'll need this later so your function can authenticate with Slack.
-
-1.  [Get the ID](https://stackoverflow.com/questions/40940327/what-is-the-simplest-way-to-find-a-slack-team-id-and-a-channel-id)
-    of the channel you want your Slack app to post to. You'll need this later so
-    your function can post to the correct channel.
+1.  [Add an **Incoming Webhook**](https://my.slack.com/services/new/incoming-webhook/) to your Slack channel and take note of the **Webhook URL**.
 1.  Clone or download this repo and open this directory in a terminal:
 
     ```shell
@@ -40,8 +25,8 @@ this:
 1.  Set the following environment variables so that the function can
     authenticate with Slack and post to the correct room:
 
-    ```
-    firebase functions:config:set slack.token="YOUR_SLACK_OAUTH_TOKEN" slack.channelid="ID_OF_YOUR_SLACK_CHANNEL"
+    ```bash
+    firebase functions:config:set slack.webhook_url="YOUR_SLACK_WEBHOOK_URL"
     ```
 
 ## Deploy and test

--- a/testlab-to-slack/functions/index.js
+++ b/testlab-to-slack/functions/index.js
@@ -1,13 +1,10 @@
 const functions = require('firebase-functions');
 
-const slackAPI = 'https://slack.com/api/chat.postMessage';
-const slackToken = functions.config().slack.token;
-const slackChannelId = functions.config().slack.channelid;
 const axios = require('axios');
 
 function postToSlack(title, details) {
   return axios.post(
-    slackAPI,
+    functions.config().slack.webhook_url,
     {
       blocks: [
         {
@@ -27,13 +24,7 @@ function postToSlack(title, details) {
             text: details
           }
         }
-      ],
-      channel: slackChannelId
-    },
-    {
-      headers: {
-        Authorization: 'Bearer ' + slackToken
-      }
+      ]
     }
   );
 }


### PR DESCRIPTION
Previously the sample requires user to set up a Slack app and provide OAuth credential token to send message to Slack.

However, these steps and configs could be replaced with a simple web hook url instead.

The existing sample `github-to-slack` also use webhook instead of Slack app and OAuth credential.