### PR TITLE
Run Firestore Quickstart with Emulator Suite

### DIFF
--- a/quickstarts/uppercase-firestore/README.md
+++ b/quickstarts/uppercase-firestore/README.md
@@ -1,40 +1,59 @@
 # Firebase SDK for Cloud Functions Quickstart - Cloud Firestore
 
-This quickstart demonstrates using **Firebase SDK for Cloud Functions** setup
-with a **Cloud Firestore**.
+This quickstart demonstrates using the **Firebase SDK for Cloud Functions** with
+**Cloud Firestore**.
 
 ## Introduction
 
 This sample app does two things:
 
-- Create messages in Cloud Firestore using a simple HTTPS request which is
+- Creates messages in Cloud Firestore using a simple HTTPS request which is
   handled by an HTTP function. Writing to Cloud Firestore is done using the
-  Firebase Admin SDK.ß
+  Firebase Admin SDK.
 - When a message gets added in the Cloud Firestore, a function triggers and
   automatically makes these messages all uppercase.
 
-1. Create a Firebase project on the
+## Run locally with the Firebase Emulator suite
+
+The
+[Firebase Local Emulator Suite](https://firebase.google.com/docs/emulator-suite)
+allows you to build and test apps on your local machine instead of deploying to
+a Firebase project.
+
+1. Create a Firebase project in the
    [Firebase Console](https://console.firebase.google.com)
-   1. The emulator needs to associate with a Firebase project to retrieve some
-      configuration values, but will run this sample completely on your local
-      machine.
-1. Set up or update the
-   [Firebase CLI](https://firebase.google.com/docs/cli#setup_update_cli)
+   > _Wondering why this step is needed?_ Even though the emulator will run this
+   > sample on your local machine, it needs to associate with a Firebase project
+   > to retrieve some configuration values.
+1. [Set up or update the Firebase CLI](https://firebase.google.com/docs/cli#setup_update_cli)
 1. Run `firebase emulators:start`
-1. Look in the logs of the output for the url of the emulator GUI. It is
-   defaults to [localhost:4000](http://localhost:4000), but may be hosted on a
-   different port on your machine. Enter that URL in your browser to open the
-   UI.
-1. Create a new message by opening the following URL in a new tab in your
-   browser:
-   `http://localhost:5001/MY_PROJECT/us-central1/addMessage?text=uppercaseme`
-   1. Replace `MY_PROJECT` with your project ID
-   1. Optionally, you can change the message "uppercaseme" to a custom message
-1. View the effects of the functions
-   1. In the "Logs" tab of the emulator GUI, you should see new logs indicating
-      that the functions "addMessage" and "makeUppercase" ran with the logs
-      `functions: Beginning execution of "addMessage"` and
-      `functions: Beginning execution of "makeUppercase"`
+1. Open the Emulator Suite UI
+   1. Look in the output of the `firebase emulators:start` command for the url
+      of the Emulator Suite UI. It defaults to
+      [localhost:4000](http://localhost:4000), but may be hosted on a different
+      port on your machine.
+   1. Enter that URL in your browser to open the UI.
+1. Trigger the functions
+   1. Look in the output of the `firebase emulators:start` command for the url
+      of the http function "addMessage". It will look similar to:
+      `http://localhost:5001/MY_PROJECT/us-central1/addMessage`
+      1. `MY_PROJECT` will be replaced with your project ID
+      1. The port may be different on your local machine
+   1. Add the query string `?text=uppercaseme` to the end of the function's URL.
+      It should now look something like:
+      `http://localhost:5001/MY_PROJECT/us-central1/addMessage?text=uppercaseme`
+      1. Optionally, you can change the message "uppercaseme" to a custom
+         message
+   1. Create a new message by opening the URL in a new tab in your browser
+1. View the effects of the functions in the Emulator Suite UI
+
+   1. In the "Logs" tab, you should see new logs indicating that the functions
+      "addMessage" and "makeUppercase" ran:
+
+      > `functions: Beginning execution of "addMessage"`
+
+      > `functions: Beginning execution of "makeUppercase"`
+
    1. In the "Firestore" tab, you should see a document containing your original
       message as well as the uppercased version of your message (if it was
       originally "uppercaseme", you'll see "UPPERCASEME")

--- a/quickstarts/uppercase-firestore/README.md
+++ b/quickstarts/uppercase-firestore/README.md
@@ -13,6 +13,11 @@ This sample app does two things:
 - When a message gets added in Cloud Firestore, a function triggers and
   automatically makes these messages all uppercase.
 
+## Set up the sample
+
+Before you can test the functions locally or deploy to a Firebase project,
+you'll need to run `npm install` in the `functions` directory.
+
 ## Run locally with the Firebase Emulator suite
 
 The
@@ -64,8 +69,6 @@ To deploy and test the sample:
 
 1. Create a Firebase project on the
    [Firebase Console](https://console.firebase.google.com)
-1. Install the required dependencies by running `npm install` in the `functions`
-   directory
 1. Deploy your project's code using `firebase deploy`
 1. Create a message by opening the following URL in your browser:
    https://us-central1-[MY_PROJECT].cloudfunctions.net/addMessage?text=uppercaseme

--- a/quickstarts/uppercase-firestore/README.md
+++ b/quickstarts/uppercase-firestore/README.md
@@ -9,11 +9,37 @@ This sample app does two things:
 
 - Create messages in Cloud Firestore using a simple HTTPS request which is
   handled by an HTTP function. Writing to Cloud Firestore is done using the
-  Firebase Admin SDK.
+  Firebase Admin SDK.ß
 - When a message gets added in the Cloud Firestore, a function triggers and
   automatically makes these messages all uppercase.
 
-## Deploy and test
+1. Create a Firebase project on the
+   [Firebase Console](https://console.firebase.google.com)
+   1. The emulator needs to associate with a Firebase project to retrieve some
+      configuration values, but will run this sample completely on your local
+      machine.
+1. Set up or update the
+   [Firebase CLI](https://firebase.google.com/docs/cli#setup_update_cli)
+1. Run `firebase emulators:start`
+1. Look in the logs of the output for the url of the emulator GUI. It is
+   defaults to [localhost:4000](http://localhost:4000), but may be hosted on a
+   different port on your machine. Enter that URL in your browser to open the
+   UI.
+1. Create a new message by opening the following URL in a new tab in your
+   browser:
+   `http://localhost:5001/MY_PROJECT/us-central1/addMessage?text=uppercaseme`
+   1. Replace `MY_PROJECT` with your project ID
+   1. Optionally, you can change the message "uppercaseme" to a custom message
+1. View the effects of the functions
+   1. In the "Logs" tab of the emulator GUI, you should see new logs indicating
+      that the functions "addMessage" and "makeUppercase" ran with the logs
+      `functions: Beginning execution of "addMessage"` and
+      `functions: Beginning execution of "makeUppercase"`
+   1. In the "Firestore" tab, you should see a document containing your original
+      message as well as the uppercased version of your message (if it was
+      originally "uppercaseme", you'll see "UPPERCASEME")
+
+## Deploy and test on a live Firebase project
 
 To deploy and test the sample:
 

--- a/quickstarts/uppercase-firestore/README.md
+++ b/quickstarts/uppercase-firestore/README.md
@@ -10,7 +10,7 @@ This sample app does two things:
 - Creates messages in Cloud Firestore using a simple HTTPS request which is
   handled by an HTTP function. Writing to Cloud Firestore is done using the
   Firebase Admin SDK.
-- When a message gets added in the Cloud Firestore, a function triggers and
+- When a message gets added in Cloud Firestore, a function triggers and
   automatically makes these messages all uppercase.
 
 ## Run locally with the Firebase Emulator suite
@@ -23,18 +23,18 @@ a Firebase project.
 1. Create a Firebase project in the
    [Firebase Console](https://console.firebase.google.com)
    > _Wondering why this step is needed?_ Even though the emulator will run this
-   > sample on your local machine, it needs to associate with a Firebase project
+   > sample on your local machine, it needs to interact with a Firebase project
    > to retrieve some configuration values.
 1. [Set up or update the Firebase CLI](https://firebase.google.com/docs/cli#setup_update_cli)
 1. Run `firebase emulators:start`
 1. Open the Emulator Suite UI
-   1. Look in the output of the `firebase emulators:start` command for the url
+   1. Look in the output of the `firebase emulators:start` command for the URL
       of the Emulator Suite UI. It defaults to
       [localhost:4000](http://localhost:4000), but may be hosted on a different
       port on your machine.
    1. Enter that URL in your browser to open the UI.
 1. Trigger the functions
-   1. Look in the output of the `firebase emulators:start` command for the url
+   1. Look in the output of the `firebase emulators:start` command for the URL
       of the http function "addMessage". It will look similar to:
       `http://localhost:5001/MY_PROJECT/us-central1/addMessage`
       1. `MY_PROJECT` will be replaced with your project ID

--- a/quickstarts/uppercase-firestore/functions/index.js
+++ b/quickstarts/uppercase-firestore/functions/index.js
@@ -20,7 +20,7 @@
 // The Cloud Functions for Firebase SDK to create Cloud Functions and setup triggers.
 const functions = require('firebase-functions');
 
-// The Firebase Admin SDK to access the Cloud Firestore.
+// The Firebase Admin SDK to access Cloud Firestore.
 const admin = require('firebase-admin');
 admin.initializeApp();
 // [END import]
@@ -50,13 +50,16 @@ exports.makeUppercase = functions.firestore.document('/messages/{documentId}')
     .onCreate((snap, context) => {
 // [END makeUppercaseTrigger]
       // [START makeUppercaseBody]
-      // Grab the current value of what was written to the Cloud Firestore.
+      // Grab the current value of what was written to Cloud Firestore.
       const original = snap.data().original;
+
       console.log('Uppercasing', context.params.documentId, original);
+      
       const uppercase = original.toUpperCase();
+      
       // You must return a Promise when performing asynchronous tasks inside a Functions such as
-      // writing to the Cloud Firestore.
-      // Setting an 'uppercase' field in the Cloud Firestore document returns a Promise.
+      // writing to Cloud Firestore.
+      // Setting an 'uppercase' field in Cloud Firestore document returns a Promise.
       return snap.ref.set({uppercase}, {merge: true});
       // [END makeUppercaseBody]
     });

--- a/quickstarts/uppercase-firestore/functions/index.js
+++ b/quickstarts/uppercase-firestore/functions/index.js
@@ -53,6 +53,7 @@ exports.makeUppercase = functions.firestore.document('/messages/{documentId}')
       // Grab the current value of what was written to Cloud Firestore.
       const original = snap.data().original;
 
+      // Access the parameter `{documentId}` with `context.params`
       console.log('Uppercasing', context.params.documentId, original);
       
       const uppercase = original.toUpperCase();


### PR DESCRIPTION
Add instructions to show how to run the Firestore uppercaser quickstart locally with the [Firebase Local Emulator Suite](https://firebase.google.com/docs/emulator-suite)