### PR TITLE
Call docChanges method according to TS definition

### DIFF
--- a/presence-firestore/public/index.js
+++ b/presence-firestore/public/index.js
@@ -128,7 +128,7 @@ function fs_listen_online() {
     firebase.firestore().collection('status')
         .where('state', '==', 'online')
         .onSnapshot(function(snapshot) {
-            snapshot.docChanges.forEach(function(change) {
+            snapshot.docChanges().forEach(function(change) {
                 if (change.type === 'added') {
                     var msg = 'User ' + change.doc.id + ' is online.';
                     console.log(msg);


### PR DESCRIPTION
TypeScript warned me this error when chaining `forEach` after `docChanges`

```
Property 'forEach' does not exist on type '(options?: SnapshotListenOptions |
undefined) => DocumentChange<DocumentData>[]'.ts(2339)
```

So I look at [the doc](https://firebase.google.com/docs/reference/js/firebase.firestore.QuerySnapshot#docchanges) and see it's an method and by calling it fixed the ts error