### PR TITLE
updated mkdirp-promise import

### DIFF
--- a/convert-images/functions/index.js
+++ b/convert-images/functions/index.js
@@ -17,7 +17,7 @@
 
 const functions = require('firebase-functions');
 const admin = require('firebase-admin');
-const mkdirp = require('mkdirp-promise');
+const mkdirp = require('mkdirp');
 const spawn = require('child-process-promise').spawn;
 const path = require('path');
 const os = require('os');


### PR DESCRIPTION
`mkdirp-promise` is deprecated so I changed it to `mkdirp` as suggested in the official documentation. It should be backwards compatible.