### PR TITLE
Update exif-images - deps and gcp storage import

### DIFF
--- a/exif-images/functions/index.js
+++ b/exif-images/functions/index.js
@@ -23,7 +23,8 @@ const os = require('os');
 
 const admin = require('firebase-admin');
 admin.initializeApp();
-const gcs = require('@google-cloud/storage')();
+const { Storage } = require("@google-cloud/storage");
+const storage = new Storage();
 const spawn = require('child-process-promise').spawn;
 
 /**
@@ -45,7 +46,7 @@ exports.metadata = functions.storage.object().onFinalize(async (object) => {
 
   let metadata;
   // Download file from bucket.
-  const bucket = gcs.bucket(object.bucket);
+  const bucket = storage.bucket(object.bucket);
   await bucket.file(filePath).download({destination: tempLocalFile});
   // Get Metadata from image.
   const result = await spawn('identify', ['-verbose', tempLocalFile], {capture: ['stdout', 'stderr']});

--- a/exif-images/functions/package.json
+++ b/exif-images/functions/package.json
@@ -2,10 +2,10 @@
   "name": "exif-images-functions",
   "description": "Extract EXIF metadata from images Firebase Functions sample",
   "dependencies": {
-    "@google-cloud/storage": "^4.3.1",
+    "@google-cloud/storage": "^5.1.0",
     "child-process-promise": "^2.2.1",
-    "firebase-admin": "~8.9.2",
-    "firebase-functions": "^3.3.0"
+    "firebase-admin": "^8.12.1",
+    "firebase-functions": "^3.7.0"
   },
   "devDependencies": {
     "eslint": "^6.8.0",
@@ -20,7 +20,7 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": "8"
+    "node": "10"
   },
   "private": true
 }


### PR DESCRIPTION
Hi firebase, this PR updates the Exif-Images example to node 10 and latest deps. 

- gcp storage 5.1.0 
- firebase-admin 8.12.1 
- fb functions 3.7.0
- node 10