### PR TITLE
Remove useless comments

### DIFF
--- a/quickstarts/time-server/functions/index.js
+++ b/quickstarts/time-server/functions/index.js
@@ -15,19 +15,15 @@
  */
 'use strict';
 
-// [START functionsimport]
 const functions = require('firebase-functions');
-// [END functionsimport]
-// [START additionalimports]
+
 // Moments library to format dates.
 const moment = require('moment');
 // CORS Express middleware to enable CORS Requests.
 const cors = require('cors')({
   origin: true,
 });
-// [END additionalimports]
 
-// [START all]
 /**
  * Returns the server's date. You must provide a `format` URL query parameter or `format` value in
  * the request body with which we'll try to format the date.
@@ -44,35 +40,26 @@ const cors = require('cors')({
  *
  * This endpoint supports CORS.
  */
-// [START trigger]
+
 exports.date = functions.https.onRequest((req, res) => {
-  // [END trigger]
-  // [START sendError]
+
   // Forbidding PUT requests.
   if (req.method === 'PUT') {
     return res.status(403).send('Forbidden!');
   }
-  // [END sendError]
 
-  // [START usingMiddleware]
   // Enable CORS using the `cors` express middleware.
   return cors(req, res, () => {
-    // [END usingMiddleware]
+
     // Reading date format from URL query parameter.
-    // [START readQueryParam]
     let format = req.query.format;
-    // [END readQueryParam]
     // Reading date format from request body query parameter
     if (!format) {
-      // [START readBodyParam]
       format = req.body.format;
-      // [END readBodyParam]
     }
-    // [START sendResponse]
+
     const formattedDate = moment().format(format);
     console.log('Sending Formatted date:', formattedDate);
     res.status(200).send(formattedDate);
-    // [END sendResponse]
   });
 });
-// [END all]


### PR DESCRIPTION
This file was cluttered with absolutely useless comments that did nothing except make the file hard to read. This file is one of the few examples that shows how to use cors with firebase functions.

For example:
```js
// [START readBodyParam]
format = req.body.format;
 // [END readBodyParam]
```
This code snippet provides **zero** additional information, however it clutters the code.

Starting the file with `[START all]` and ending with `[END all]` is once again an example of a useless comment. It's obvious that the code starts there, and ends there.

Comments should be used only for documentation, clarification, and nuances/things that need to be pointed out to future contributors.