### PR TITLE
docs: remove all references of the Flame plan

### DIFF
--- a/authenticated-json-api/README.md
+++ b/authenticated-json-api/README.md
@@ -14,7 +14,7 @@ detected by the [Cloud Natural Language API](https://cloud.google.com/natural-la
 
  1. Create a Firebase Project using the [Firebase Console](https://console.firebase.google.com).
  1. Enable the **Google** Provider in the **Auth** section.
- 1. Enable Billing on your project (to connect to the Natural Language API) by switching to the Blaze or Flame plan.
+ 1. Enable Billing on your project (to connect to the Natural Language API) by switching to the Blaze plan.
  1. Clone or download this repo and open the `authenticated-json-api` directory.
  1. You must have the Firebase CLI installed. If you don't have it install it with `npm install -g firebase-tools` and then configure it with `firebase login`.
  1. Configure the CLI locally by using `firebase use --add` and select your project in the list.

--- a/fulltext-search/README.md
+++ b/fulltext-search/README.md
@@ -45,7 +45,7 @@ tree.
 
 Create an Algolia account at [www.algolia.com](https://www.algolia.com/).
 
-Enable Billing on your Firebase project by switching to the Blaze or Flame plans you need billing enabled to allow external requests. For more information have a look at the [pricing page](https://firebase.google.com/pricing/).
+Enable Billing on your Firebase project by switching to the Blaze plan. You need billing enabled to allow external requests. For more information have a look at the [pricing page](https://firebase.google.com/pricing/).
 
 Set the `algolia.app_id` and `algolia.api_key` Google Cloud environment variables to match the Algolia application ID and API key of your account. For this use:
 

--- a/github-to-slack/README.md
+++ b/github-to-slack/README.md
@@ -19,7 +19,7 @@ The dependencies are listed in [functions/package.json](functions/package.json).
 To test this integration:
 
  - Create a Firebase Project using the [Firebase Developer Console](https://console.firebase.google.com)
- - Enable billing on your project by switching to the Blaze or Flame plan. See [pricing](https://firebase.google.com/pricing/) for more details. This is required to be able to do requests to non-Google services.
+ - Enable billing on your project by switching to the Blaze plan. See [pricing](https://firebase.google.com/pricing/) for more details. This is required to be able to do requests to non-Google services.
  - Configure this sample to use your project using `firebase use --add` and select your project.
  - Install dependencies locally by running: `cd functions; npm install; cd -`
  - [Add a WebHook to your GitHub repo](https://help.github.com/articles/about-webhooks/) with the following settings:

--- a/moderate-images/README.md
+++ b/moderate-images/README.md
@@ -18,7 +18,7 @@ The function triggers on upload of any file to your Firebase project's default C
 ## Setting up the sample
 
  1. Create a Firebase project on the [Firebase Console](https://console.firebase.google.com).
- 1. In the Google Cloud Console [enable the **Google Cloud Vision API**](https://console.cloud.google.com/apis/api/vision.googleapis.com/overview?project=_). Note: Billing is required to enable the Cloud Vision API so enable Billing on your Firebase project by switching to the Blaze or Flame plans. For more information have a look at the [pricing page](https://firebase.google.com/pricing/).
+ 1. In the Google Cloud Console [enable the **Google Cloud Vision API**](https://console.cloud.google.com/apis/api/vision.googleapis.com/overview?project=_). Note: Billing is required to enable the Cloud Vision API so enable Billing on your Firebase project by switching to the Blaze plan. For more information have a look at the [pricing page](https://firebase.google.com/pricing/).
  1. Clone or download this repo and open the `moderate-image` directory.
  1. You must have the Firebase CLI installed. If you don't have it install it with `npm install -g firebase-tools` and then configure it with `firebase login`.
  1. Configure the CLI locally by using `firebase use --add` and select your project in the list.

--- a/paypal/README.md
+++ b/paypal/README.md
@@ -22,7 +22,7 @@ The dependencies are listed in [functions/package.json](functions/package.json).
 ## Setting up the sample
 
  1. Create a Firebase project on the [Firebase application console](https://console.firebase.google.com).
- 1. Enable billing on your Firebase project by switching to the Blaze or Flame plan. See [pricing](https://firebase.google.com/pricing/) for more details. This is required to be able to do requests to non-Google services.
+ 1. Enable billing on your Firebase project by switching to the Blaze plan. See [pricing](https://firebase.google.com/pricing/) for more details. This is required to be able to do requests to non-Google services.
  1. Clone or download this repo and open the `paypal` directory.
  1. You must have the Firebase CLI installed. If you don't have it install it with `npm install -g firebase-tools` and then configure it with `firebase login`.
  1. Configure the CLI locally by using `firebase use --add` and select your project in the list.

--- a/spotify-auth/README.md
+++ b/spotify-auth/README.md
@@ -7,7 +7,7 @@ This sample shows how to authenticate using Spotify Sign-In on Firebase. In this
 
 Create and setup the Firebase project:
  1. Create a Firebase project using the [Firebase Developer Console](https://console.firebase.google.com).
- 1. Enable Billing on your Firebase project by switching to the **Blaze** or **Flame** plan, this is currently needed to be able to perform HTTP requests to external services from a Cloud Function. See the [pricing](https://firebase.google.com/pricing/) page for more details.
+ 1. Enable Billing on your Firebase project by switching to the **Blaze** plan, this is currently needed to be able to perform HTTP requests to external services from a Cloud Function. See the [pricing](https://firebase.google.com/pricing/) page for more details.
 
 Create and provide a Service Account's credentials:
  1. Create a Service Accounts file as described in the [Server SDK setup instructions](https://firebase.google.com/docs/server/setup#add_firebase_to_your_app).

--- a/stripe/README.md
+++ b/stripe/README.md
@@ -25,7 +25,7 @@ This sample shows you how to create Stripe customers when your users sign up, se
 ## Deploy and test
 
 - Create a Firebase Project using the [Firebase Developer Console](https://console.firebase.google.com)
-- Enable billing on your project by switching to the Blaze or Flame plan. See [pricing](https://firebase.google.com/pricing/) for more details. This is required to be able to do requests to non-Google services.
+- Enable billing on your project by switching to the Blaze plan. See [pricing](https://firebase.google.com/pricing/) for more details. This is required to be able to do requests to non-Google services.
 - Enable Google & Email sign-in in your [authentication provider settings](https://console.firebase.google.com/project/_/authentication/providers).
 - Install [Firebase CLI Tools](https://github.com/firebase/firebase-tools) if you have not already and log in with `firebase login`.
 - Configure this sample to use your project using `firebase use --add` and select your project.


### PR DESCRIPTION
Removing all references about the flame plan from our docs, since it is no longer offered by Firebase.