### PR TITLE
Add missing firebase-database script causing Presence Firestore example to error out

### DIFF
--- a/presence-firestore/README.md
+++ b/presence-firestore/README.md
@@ -8,6 +8,13 @@ See file [functions/index.js](functions/index.js) for the code.
 
 The dependencies are listed in [functions/package.json](functions/package.json).
 
+To install:
+
+```sh
+cd functions
+npm install
+```
+
 ## Sample Database Structure
 
 As an example we'll be using a secure note structure:
@@ -20,4 +27,22 @@ As an example we'll be using a secure note structure:
         state: "offline"
 ```
 
-Whenever a new note is created or modified a Function sends the content to be indexed to the Algolia instance.
+Whenever a new note is created or modified a Function sends the content to be indexed to the Firestore instance.
+
+## Sample Client Code
+
+The sample client app in [public/index.html](public/index.html) and [public/index.js](public/index.js) will anonymously log in the user, create `status/UID_A` with a `last_changed` and `state` in `Realtime Database`, then mirror that over to a `UID_A` document in the app's `Firestore` collection `status`.
+
+To deploy the sample to your Firebase app,
+
+1. Run `npm install` to install dependencies for the server-side [functions](functions/) as detailed above.
+2. From this top-level sample directory, deploy the `Realtime Database` trigger defined in [functions](functions/) to `Firebase Functions` and the [public](public/) directory app to `Firebase Hosting`.
+
+Assumimg you've created a Firebase application called `firebase-example-123` (make sure it's upgraded to the Spark plan and that `Anonymous Authentication` are enabled).
+
+```sh
+firebase use --add firebase-example-123
+firebase deploy
+```
+
+Then visit `https://firebase-example-123.web.app` in your browser and you should see `User <UID_A>` is online written to the index file, as well as the associated data in `Realtime Database` and `Firestore`.

--- a/presence-firestore/public/index.html
+++ b/presence-firestore/public/index.html
@@ -25,8 +25,9 @@
         <!-- If you do not serve/host your project using Firebase Hosting see https://firebase.google.com/docs/web/setup -->
         <script src="/__/firebase/8.2.1/firebase-app.js"></script>
         <script src="/__/firebase/8.2.1/firebase-auth.js"></script>
+        <script src="/__/firebase/8.2.1/firebase-database.js"></script>
         <script src="/__/firebase/8.2.1/firebase-firestore.js"></script>
-        
+   
         <script src="/__/firebase/init.js"></script>
 
         <script src="./index.js"></script>


### PR DESCRIPTION
Add missing `firebase-database` script that was causing `public/index.js` to error out and add description for running and deploying sample client code to Firebase Hosting and Firebase Functions.

```js
TypeError: firebase.database is not a function. (In 'firebase.database()', 'firebase.database' is undefined) (index.js, line 155)
```

Fixes #813 