### PR TITLE
Fix OAuth2.0 based authentication examples problems using cookie

### DIFF
--- a/instagram-auth/functions/index.js
+++ b/instagram-auth/functions/index.js
@@ -64,6 +64,7 @@ exports.redirect = functions.https.onRequest((req, res) => {
       maxAge: 3600000,
       secure: true,
       httpOnly: true,
+      sameSite: 'none',
     });
     const redirectUri = oauth2.authorizationCode.authorizeURL({
       redirect_uri: OAUTH_REDIRECT_URI,

--- a/linkedin-auth/functions/index.js
+++ b/linkedin-auth/functions/index.js
@@ -56,6 +56,7 @@ exports.redirect = functions.https.onRequest((req, res) => {
       maxAge: 3600000,
       secure: true,
       httpOnly: true,
+      sameSite: 'none',
     });
     Linkedin.auth.authorize(res, OAUTH_SCOPES, state.toString());
   });

--- a/spotify-auth/functions/index.js
+++ b/spotify-auth/functions/index.js
@@ -48,7 +48,7 @@ exports.redirect = functions.https.onRequest((req, res) => {
   cookieParser()(req, res, () => {
     const state = req.cookies.state || crypto.randomBytes(20).toString('hex');
     console.log('Setting verification state:', state);
-    res.cookie('state', state.toString(), {maxAge: 3600000, secure: true, httpOnly: true});
+    res.cookie('state', state.toString(), {maxAge: 3600000, secure: true, httpOnly: true, sameSite: 'none'});
     const authorizeURL = Spotify.createAuthorizeURL(OAUTH_SCOPES, state.toString());
     res.redirect(authorizeURL);
   });


### PR DESCRIPTION
Some examples using OAuth 2.0 based authentication with cookie doesn't work correctly in modern browser like Google Chrome and Firefox.
In these examples, `state` value are not set correctly in cookie because the requests for Cloud Functions are sent in cross domain and are not Top Level Navigation.
If `SameSite` attribute are not set, browsers treats it as `Lax` value by default.  So I think `SameSite` attributes should be set to `None`.