### PR TITLE
Changed getLastSignInTimestamp to getLastRefreshTimestamp in detectio…

### DIFF
--- a/delete-unused-accounts-cron/functions/index.js
+++ b/delete-unused-accounts-cron/functions/index.js
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
+"use strict";
 
-const functions = require('firebase-functions');
-const admin = require('firebase-admin');
+const functions = require("firebase-functions");
+const admin = require("firebase-admin");
 admin.initializeApp();
-const PromisePool = require('es6-promise-pool').default;
+const PromisePool = require("es6-promise-pool").default;
 // Maximum concurrent account deletions.
 const MAX_CONCURRENT = 3;
 
@@ -26,14 +26,19 @@ const MAX_CONCURRENT = 3;
  * Run once a day at midnight, to cleanup the users
  * Manually run the task here https://console.cloud.google.com/cloudscheduler
  */
-exports.accountcleanup = functions.pubsub.schedule('every day 00:00').onRun(async context => {
-  // Fetch all user details.
-  const inactiveUsers = await getInactiveUsers();
-  // Use a pool so that we delete maximum `MAX_CONCURRENT` users in parallel.
-  const promisePool = new PromisePool(() => deleteInactiveUser(inactiveUsers), MAX_CONCURRENT);
-  await promisePool.start();
-  console.log('User cleanup finished');
-});
+exports.accountcleanup = functions.pubsub
+  .schedule("every day 00:00")
+  .onRun(async (context) => {
+    // Fetch all user details.
+    const inactiveUsers = await getInactiveUsers();
+    // Use a pool so that we delete maximum `MAX_CONCURRENT` users in parallel.
+    const promisePool = new PromisePool(
+      () => deleteInactiveUser(inactiveUsers),
+      MAX_CONCURRENT
+    );
+    await promisePool.start();
+    console.log("User cleanup finished");
+  });
 
 /**
  * Deletes one inactive user from the list.
@@ -41,13 +46,26 @@ exports.accountcleanup = functions.pubsub.schedule('every day 00:00').onRun(asyn
 function deleteInactiveUser(inactiveUsers) {
   if (inactiveUsers.length > 0) {
     const userToDelete = inactiveUsers.pop();
-    
+
     // Delete the inactive user.
-    return admin.auth().deleteUser(userToDelete.uid).then(() => {
-      return console.log('Deleted user account', userToDelete.uid, 'because of inactivity');
-    }).catch((error) => {
-      return console.error('Deletion of inactive user account', userToDelete.uid, 'failed:', error);
-    });
+    return admin
+      .auth()
+      .deleteUser(userToDelete.uid)
+      .then(() => {
+        return console.log(
+          "Deleted user account",
+          userToDelete.uid,
+          "because of inactivity"
+        );
+      })
+      .catch((error) => {
+        return console.error(
+          "Deletion of inactive user account",
+          userToDelete.uid,
+          "failed:",
+          error
+        );
+      });
   } else {
     return null;
   }
@@ -60,15 +78,18 @@ async function getInactiveUsers(users = [], nextPageToken) {
   const result = await admin.auth().listUsers(1000, nextPageToken);
   // Find users that have not signed in in the last 30 days.
   const inactiveUsers = result.users.filter(
-      user => Date.parse(user.metadata.lastSignInTime) < (Date.now() - 30 * 24 * 60 * 60 * 1000));
-  
+    (user) =>
+      Date.parse(user.metadata.getLastRefreshTimestamp) <
+      Date.now() - 30 * 24 * 60 * 60 * 1000
+  );
+
   // Concat with list of previously found inactive users if there was more than 1000 users.
   users = users.concat(inactiveUsers);
-  
+
   // If there are more users to fetch we fetch them.
   if (result.pageToken) {
     return getInactiveUsers(users, result.pageToken);
   }
-  
+
   return users;
 }


### PR DESCRIPTION
Changed `getLastSignInTimestamp` to `getLastRefreshTimestamp` in detection of inactive users because `getLastSignInTimestamp` is only changed when user signs in and `getLastRefreshTimestamp` shows the real last active timestamp. If the user doesn't manuelly logout and login again the `getLastSignInTimestamp` can very easiely get older then one month and we get a lot active users deleted.