### PR TITLE
Switch all samples from console.log to functions.logger.log

### DIFF
--- a/authenticated-json-api/functions/index.js
+++ b/authenticated-json-api/functions/index.js
@@ -62,7 +62,7 @@ app.use(authenticate);
 app.post('/api/messages', async (req, res) => {
   const message = req.body.message;
 
-  console.log(`ANALYZING MESSAGE: "${message}"`);
+  functions.logger.log(`ANALYZING MESSAGE: "${message}"`);
 
   try {
     const results = await client.analyzeSentiment({
@@ -78,7 +78,10 @@ app.post('/api/messages', async (req, res) => {
 
     res.status(201).json({message, category});
   } catch(error) {
-    console.log('Error detecting sentiment or saving message', error.message);
+    functions.logger.log(
+      'Error detecting sentiment or saving message',
+      error.message
+    );
     res.sendStatus(500);
   }
 });
@@ -109,7 +112,7 @@ app.get('/api/messages', async (req, res) => {
 
     res.status(200).json(messages);
   } catch(error) {
-    console.log('Error getting messages', error.message);
+    functions.logger.log('Error getting messages', error.message);
     res.sendStatus(500);
   }
 });
@@ -119,7 +122,7 @@ app.get('/api/messages', async (req, res) => {
 app.get('/api/message/:messageId', async (req, res) => {
   const messageId = req.params.messageId;
 
-  console.log(`LOOKING UP MESSAGE "${messageId}"`);
+  functions.logger.log(`LOOKING UP MESSAGE "${messageId}"`);
 
   try {
     // @ts-ignore
@@ -132,7 +135,11 @@ app.get('/api/message/:messageId', async (req, res) => {
     res.set('Cache-Control', 'private, max-age=300');
     return res.status(200).json(snapshot.val());
   } catch(error) {
-    console.log('Error getting message details', messageId, error.message);
+    functions.logger.log(
+      'Error getting message details',
+      messageId,
+      error.message
+    );
     return res.sendStatus(500);
   }
 });

--- a/authorized-https-endpoint/functions/index.js
+++ b/authorized-https-endpoint/functions/index.js
@@ -28,25 +28,27 @@ const app = express();
 // `Authorization: Bearer <Firebase ID Token>`.
 // when decoded successfully, the ID Token content will be added as `req.user`.
 const validateFirebaseIdToken = async (req, res, next) => {
-  console.log('Check if request is authorized with Firebase ID token');
+  functions.logger.log('Check if request is authorized with Firebase ID token');
 
   if ((!req.headers.authorization || !req.headers.authorization.startsWith('Bearer ')) &&
       !(req.cookies && req.cookies.__session)) {
-    console.error('No Firebase ID token was passed as a Bearer token in the Authorization header.',
-        'Make sure you authorize your request by providing the following HTTP header:',
-        'Authorization: Bearer <Firebase ID Token>',
-        'or by passing a "__session" cookie.');
+    functions.logger.error(
+      'No Firebase ID token was passed as a Bearer token in the Authorization header.',
+      'Make sure you authorize your request by providing the following HTTP header:',
+      'Authorization: Bearer <Firebase ID Token>',
+      'or by passing a "__session" cookie.'
+    );
     res.status(403).send('Unauthorized');
     return;
   }
 
   let idToken;
   if (req.headers.authorization && req.headers.authorization.startsWith('Bearer ')) {
-    console.log('Found "Authorization" header');
+    functions.logger.log('Found "Authorization" header');
     // Read the ID Token from the Authorization header.
     idToken = req.headers.authorization.split('Bearer ')[1];
   } else if(req.cookies) {
-    console.log('Found "__session" cookie');
+    functions.logger.log('Found "__session" cookie');
     // Read the ID Token from cookie.
     idToken = req.cookies.__session;
   } else {
@@ -57,12 +59,12 @@ const validateFirebaseIdToken = async (req, res, next) => {
 
   try {
     const decodedIdToken = await admin.auth().verifyIdToken(idToken);
-    console.log('ID Token correctly decoded', decodedIdToken);
+    functions.logger.log('ID Token correctly decoded', decodedIdToken);
     req.user = decodedIdToken;
     next();
     return;
   } catch (error) {
-    console.error('Error while verifying Firebase ID token:', error);
+    functions.logger.error('Error while verifying Firebase ID token:', error);
     res.status(403).send('Unauthorized');
     return;
   }

--- a/child-count/functions/index.js
+++ b/child-count/functions/index.js
@@ -39,7 +39,7 @@ exports.countlikechange = functions.database.ref('/posts/{postid}/likes/{likeid}
       await countRef.transaction((current) => {
         return (current || 0) + increment;
       });
-      console.log('Counter updated.');
+      functions.logger.log('Counter updated.');
       return null;
     });
 

--- a/convert-images/functions/index.js
+++ b/convert-images/functions/index.js
@@ -43,13 +43,13 @@ exports.imageToJPG = functions.storage.object().onFinalize(async (object) => {
 
   // Exit if this is triggered on a file that is not an image.
   if (!object.contentType.startsWith('image/')) {
-    console.log('This is not an image.');
+    functions.logger.log('This is not an image.');
     return null;
   }
 
   // Exit if the image is already a JPEG.
   if (object.contentType.startsWith('image/jpeg')) {
-    console.log('Already a JPEG.');
+    functions.logger.log('Already a JPEG.');
     return null;
   }
 
@@ -58,13 +58,13 @@ exports.imageToJPG = functions.storage.object().onFinalize(async (object) => {
   await mkdirp(tempLocalDir);
   // Download file from bucket.
   await bucket.file(filePath).download({destination: tempLocalFile});
-  console.log('The file has been downloaded to', tempLocalFile);
+  functions.logger.log('The file has been downloaded to', tempLocalFile);
   // Convert the image to JPEG using ImageMagick.
   await spawn('convert', [tempLocalFile, tempLocalJPEGFile]);
-  console.log('JPEG image created at', tempLocalJPEGFile);
+  functions.logger.log('JPEG image created at', tempLocalJPEGFile);
   // Uploading the JPEG image.
   await bucket.upload(tempLocalJPEGFile, {destination: JPEGFilePath});
-  console.log('JPEG image uploaded to Storage at', JPEGFilePath);
+  functions.logger.log('JPEG image uploaded to Storage at', JPEGFilePath);
   // Once the image has been converted delete the local files to free up disk space.
   fs.unlinkSync(tempLocalJPEGFile);
   fs.unlinkSync(tempLocalFile);

--- a/delete-unused-accounts-cron/functions/index.js
+++ b/delete-unused-accounts-cron/functions/index.js
@@ -32,7 +32,7 @@ exports.accountcleanup = functions.pubsub.schedule('every day 00:00').onRun(asyn
   // Use a pool so that we delete maximum `MAX_CONCURRENT` users in parallel.
   const promisePool = new PromisePool(() => deleteInactiveUser(inactiveUsers), MAX_CONCURRENT);
   await promisePool.start();
-  console.log('User cleanup finished');
+  functions.logger.log('User cleanup finished');
 });
 
 /**
@@ -44,9 +44,18 @@ function deleteInactiveUser(inactiveUsers) {
     
     // Delete the inactive user.
     return admin.auth().deleteUser(userToDelete.uid).then(() => {
-      return console.log('Deleted user account', userToDelete.uid, 'because of inactivity');
+      return functions.logger.log(
+        'Deleted user account',
+        userToDelete.uid,
+        'because of inactivity'
+      );
     }).catch((error) => {
-      return console.error('Deletion of inactive user account', userToDelete.uid, 'failed:', error);
+      return functions.logger.error(
+        'Deletion of inactive user account',
+        userToDelete.uid,
+        'failed:',
+        error
+      );
     });
   } else {
     return null;

--- a/email-confirmation/functions/index.js
+++ b/email-confirmation/functions/index.js
@@ -54,9 +54,15 @@ exports.sendEmailConfirmation = functions.database.ref('/users/{uid}').onWrite(a
   
   try {
     await mailTransport.sendMail(mailOptions);
-    console.log(`New ${subscribed ? '' : 'un'}subscription confirmation email sent to:`, val.email);
+    functions.logger.log(
+      `New ${subscribed ? '' : 'un'}subscription confirmation email sent to:`,
+      val.email
+    );
   } catch(error) {
-    console.error('There was an error while sending the email:', error);
+    functions.logger.error(
+      'There was an error while sending the email:',
+      error
+    );
   }
   return null;
 });

--- a/exif-images/functions/index.js
+++ b/exif-images/functions/index.js
@@ -41,7 +41,7 @@ exports.metadata = functions.storage.object().onFinalize(async (object) => {
 
   // Exit if this is triggered on a file that is not an image.
   if (!object.contentType.startsWith('image/')) {
-    console.log('This is not an image.');
+    functions.logger.log('This is not an image.');
     return null;
   }
 
@@ -55,11 +55,11 @@ exports.metadata = functions.storage.object().onFinalize(async (object) => {
   metadata = imageMagickOutputToObject(result.stdout);
   const safeKey = makeKeyFirebaseCompatible(filePath);
   await admin.database().ref(safeKey).set(metadata);
-  console.log('Wrote to:', filePath, 'data:', metadata);
+  functions.logger.log('Wrote to:', filePath, 'data:', metadata);
   // Cleanup temp directory after metadata is extracted
   // Remove the file from temp directory
   await fs.unlinkSync(tempLocalFile)
-  return console.log('cleanup successful!');
+  return functions.logger.log('cleanup successful!');
 });
 
 /**
@@ -88,7 +88,7 @@ function imageMagickOutputToObject(output) {
   output = lines.join('');
   output = '{' + output.substring(0, output.length - 1) + '}'; // remove trailing comma.
   output = JSON.parse(output);
-  console.log('Metadata extracted from image', output);
+  functions.logger.log('Metadata extracted from image', output);
   return output;
 }
 

--- a/fcm-notifications/functions/index.js
+++ b/fcm-notifications/functions/index.js
@@ -31,9 +31,19 @@ exports.sendFollowerNotification = functions.database.ref('/followers/{followedU
       const followedUid = context.params.followedUid;
       // If un-follow we exit the function.
       if (!change.after.val()) {
-        return console.log('User ', followerUid, 'un-followed user', followedUid);
+        return functions.logger.log(
+          'User ',
+          followerUid,
+          'un-followed user',
+          followedUid
+        );
       }
-      console.log('We have a new follower UID:', followerUid, 'for user:', followedUid);
+      functions.logger.log(
+        'We have a new follower UID:',
+        followerUid,
+        'for user:',
+        followedUid
+      );
 
       // Get the list of device notification tokens.
       const getDeviceTokensPromise = admin.database()
@@ -54,10 +64,16 @@ exports.sendFollowerNotification = functions.database.ref('/followers/{followedU
 
       // Check if there are any device tokens.
       if (!tokensSnapshot.hasChildren()) {
-        return console.log('There are no notification tokens to send to.');
+        return functions.logger.log(
+          'There are no notification tokens to send to.'
+        );
       }
-      console.log('There are', tokensSnapshot.numChildren(), 'tokens to send notifications to.');
-      console.log('Fetched follower profile', follower);
+      functions.logger.log(
+        'There are',
+        tokensSnapshot.numChildren(),
+        'tokens to send notifications to.'
+      );
+      functions.logger.log('Fetched follower profile', follower);
 
       // Notification details.
       const payload = {
@@ -77,7 +93,11 @@ exports.sendFollowerNotification = functions.database.ref('/followers/{followedU
       response.results.forEach((result, index) => {
         const error = result.error;
         if (error) {
-          console.error('Failure sending notification to', tokens[index], error);
+          functions.logger.error(
+            'Failure sending notification to',
+            tokens[index],
+            error
+          );
           // Cleanup the tokens who are not registered anymore.
           if (error.code === 'messaging/invalid-registration-token' ||
               error.code === 'messaging/registration-token-not-registered') {

--- a/ffmpeg-convert-audio/functions/index.js
+++ b/ffmpeg-convert-audio/functions/index.js
@@ -43,7 +43,7 @@ exports.generateMonoAudio = functions.storage.object().onFinalize(async (object)
 
   // Exit if this is triggered on a file that is not an audio.
   if (!contentType.startsWith('audio/')) {
-    console.log('This is not an audio.');
+    functions.logger.log('This is not an audio.');
     return null;
   }
 
@@ -51,7 +51,7 @@ exports.generateMonoAudio = functions.storage.object().onFinalize(async (object)
   const fileName = path.basename(filePath);
   // Exit if the audio is already converted.
   if (fileName.endsWith('_output.flac')) {
-    console.log('Already a converted audio.');
+    functions.logger.log('Already a converted audio.');
     return null;
   }
 
@@ -64,7 +64,7 @@ exports.generateMonoAudio = functions.storage.object().onFinalize(async (object)
   const targetStorageFilePath = path.join(path.dirname(filePath), targetTempFileName);
 
   await bucket.file(filePath).download({destination: tempFilePath});
-  console.log('Audio downloaded locally to', tempFilePath);
+  functions.logger.log('Audio downloaded locally to', tempFilePath);
   // Convert the audio to mono channel using FFMPEG.
 
   let command = ffmpeg(tempFilePath)
@@ -75,14 +75,14 @@ exports.generateMonoAudio = functions.storage.object().onFinalize(async (object)
       .output(targetTempFilePath);
 
   await promisifyCommand(command);
-  console.log('Output audio created at', targetTempFilePath);
+  functions.logger.log('Output audio created at', targetTempFilePath);
   // Uploading the audio.
   await bucket.upload(targetTempFilePath, {destination: targetStorageFilePath});
-  console.log('Output audio uploaded to', targetStorageFilePath);
+  functions.logger.log('Output audio uploaded to', targetStorageFilePath);
 
   // Once the audio has been uploaded delete the local file to free up disk space.
   fs.unlinkSync(tempFilePath);
   fs.unlinkSync(targetTempFilePath);
 
-  return console.log('Temporary files removed.', targetTempFilePath);
+  return functions.logger.log('Temporary files removed.', targetTempFilePath);
 });

--- a/fulltext-search-firestore/functions/index.js
+++ b/fulltext-search-firestore/functions/index.js
@@ -49,30 +49,30 @@ const admin = require('firebase-admin');
 admin.initializeApp();
 
 async function getFirebaseUser(req, res, next) {
-  console.log('Check if request is authorized with Firebase ID token');
+  functions.logger.log('Check if request is authorized with Firebase ID token');
 
   if (!req.headers.authorization || !req.headers.authorization.startsWith('Bearer ')) {
-    console.error(
+    functions.logger.error(
       'No Firebase ID token was passed as a Bearer token in the Authorization header.',
       'Make sure you authorize your request by providing the following HTTP header:',
       'Authorization: Bearer <Firebase ID Token>'
-      );
+    );
     return res.sendStatus(403);
   }
 
   let idToken;
   if (req.headers.authorization && req.headers.authorization.startsWith('Bearer ')) {
-    console.log('Found \'Authorization\' header');
+    functions.logger.log("Found 'Authorization' header");
     idToken = req.headers.authorization.split('Bearer ')[1];
   }
 
   try {
     const decodedIdToken = await admin.auth().verifyIdToken(idToken);
-    console.log('ID Token correctly decoded', decodedIdToken);
+    functions.logger.log('ID Token correctly decoded', decodedIdToken);
     req.user = decodedIdToken;
     return next();
   } catch(error) {
-    console.error('Error while verifying Firebase ID token:', error);
+    functions.logger.error('Error while verifying Firebase ID token:', error);
     return res.status(403).send('Unauthorized');
   }
 }

--- a/generate-thumbnail/functions/index.js
+++ b/generate-thumbnail/functions/index.js
@@ -49,12 +49,12 @@ exports.generateThumbnail = functions.storage.object().onFinalize(async (object)
 
   // Exit if this is triggered on a file that is not an image.
   if (!contentType.startsWith('image/')) {
-    return console.log('This is not an image.');
+    return functions.logger.log('This is not an image.');
   }
 
   // Exit if the image is already a thumbnail.
   if (fileName.startsWith(THUMB_PREFIX)) {
-    return console.log('Already a Thumbnail.');
+    return functions.logger.log('Already a Thumbnail.');
   }
 
   // Cloud Storage files.
@@ -71,13 +71,13 @@ exports.generateThumbnail = functions.storage.object().onFinalize(async (object)
   await mkdirp(tempLocalDir)
   // Download file from bucket.
   await file.download({destination: tempLocalFile});
-  console.log('The file has been downloaded to', tempLocalFile);
+  functions.logger.log('The file has been downloaded to', tempLocalFile);
   // Generate a thumbnail using ImageMagick.
   await spawn('convert', [tempLocalFile, '-thumbnail', `${THUMB_MAX_WIDTH}x${THUMB_MAX_HEIGHT}>`, tempLocalThumbFile], {capture: ['stdout', 'stderr']});
-  console.log('Thumbnail created at', tempLocalThumbFile);
+  functions.logger.log('Thumbnail created at', tempLocalThumbFile);
   // Uploading the Thumbnail.
   await bucket.upload(tempLocalThumbFile, {destination: thumbFilePath, metadata: metadata});
-  console.log('Thumbnail uploaded to Storage at', thumbFilePath);
+  functions.logger.log('Thumbnail uploaded to Storage at', thumbFilePath);
   // Once the image has been uploaded delete the local files to free up disk space.
   fs.unlinkSync(tempLocalFile);
   fs.unlinkSync(tempLocalThumbFile);
@@ -92,12 +92,12 @@ exports.generateThumbnail = functions.storage.object().onFinalize(async (object)
       expires: '03-01-2500',
     }),
   ]);
-  console.log('Got Signed URLs.');
+  functions.logger.log('Got Signed URLs.');
   const thumbResult = results[0];
   const originalResult = results[1];
   const thumbFileUrl = thumbResult[0];
   const fileUrl = originalResult[0];
   // Add the URLs to the Database
   await admin.database().ref('images').push({path: fileUrl, thumbnail: thumbFileUrl});
-  return console.log('Thumbnail URLs saved to database.');
+  return functions.logger.log('Thumbnail URLs saved to database.');
 });

--- a/github-to-slack/functions/index.js
+++ b/github-to-slack/functions/index.js
@@ -36,7 +36,12 @@ exports.githubWebhook = functions.https.onRequest(async (req, res) => {
 
   // Check that the body of the request has been signed with the GitHub Secret.
   if (!secureCompare(signature, expectedSignature)) {
-    console.error('x-hub-signature', signature, 'did not match', expectedSignature);
+    functions.logger.error(
+      'x-hub-signature',
+      signature,
+      'did not match',
+      expectedSignature
+    );
     res.status(403).send('Your x-hub-signature\'s bad and you should feel bad!');
     return;
   }
@@ -45,7 +50,7 @@ exports.githubWebhook = functions.https.onRequest(async (req, res) => {
     await postToSlack(req.body.compare, req.body.commits.length, req.body.repository);
     res.end();
   } catch(error) {
-    console.error(error);
+    functions.logger.error(error);
     res.status(500).send('Something went wrong while posting the message to Slack.');
   }
 });

--- a/google-sheet-sync/functions/index.js
+++ b/google-sheet-sync/functions/index.js
@@ -99,7 +99,7 @@ function appendPromise(requestWithoutAuth) {
       request.auth = client;
       return sheets.spreadsheets.values.append(request, (err, response) => {
         if (err) {
-          console.log(`The API returned an error: ${err}`);
+          functions.logger.log(`The API returned an error: ${err}`);
           return reject(err);
         }
         return resolve(response.data);

--- a/image-sharp/functions/index.js
+++ b/image-sharp/functions/index.js
@@ -36,7 +36,7 @@ exports.generateThumbnail = functions.storage.object().onFinalize((object) => {
 
   // Exit if this is triggered on a file that is not an image.
   if (!contentType.startsWith('image/')) {
-    console.log('This is not an image.');
+    functions.logger.log('This is not an image.');
     return null;
   }
 
@@ -44,7 +44,7 @@ exports.generateThumbnail = functions.storage.object().onFinalize((object) => {
   const fileName = path.basename(filePath);
   // Exit if the image is already a thumbnail.
   if (fileName.startsWith('thumb_')) {
-    console.log('Already a Thumbnail.');
+    functions.logger.log('Already a Thumbnail.');
     return null;
   }
 

--- a/minimal-webhook/functions/index.js
+++ b/minimal-webhook/functions/index.js
@@ -36,5 +36,5 @@ exports.webhook = functions.database.ref('/hooks/{hookId}').onCreate(async (snap
   if (response.statusCode >= 400) {
     throw new Error(`HTTP Error: ${response.statusCode}`);
   }
-  console.log('SUCCESS! Posted', snap.ref);
+  functions.logger.log('SUCCESS! Posted', snap.ref);
 });

--- a/okta-auth/functions/index.js
+++ b/okta-auth/functions/index.js
@@ -49,7 +49,7 @@ const oktaAuth = async (req, res, next) => {
         req.jwt = jwt;
         return next();
     } catch (err) {
-        console.log(err.message);
+        functions.logger.log(err.message);
         res.status(401);
         return next('Unauthorized');
     }
@@ -63,7 +63,7 @@ app.get('/firebaseCustomToken', [cors, oktaAuth], async (req, res) => {
                 await firebaseApp.auth().createCustomToken(oktaUid);
         res.send(firebaseToken);
     } catch (err) {
-        console.log(err.message);
+        functions.logger.log(err.message);
         res.status(500).send('Error minting token.');
     }
 });

--- a/presence-firestore/functions/index.js
+++ b/presence-firestore/functions/index.js
@@ -41,7 +41,7 @@ exports.onUserStatusChanged = functions.database.ref('/status/{uid}').onUpdate(
       // and compare the timestamps.
       const statusSnapshot = await change.after.ref.once('value');
       const status = statusSnapshot.val();
-      console.log(status, eventStatus);
+      functions.logger.log(status, eventStatus);
       // If the current timestamp for this data is newer than
       // the data that triggered this event, we exit this function.
       if (status.last_changed > eventStatus.last_changed) {

--- a/publish-model/functions/index.js
+++ b/publish-model/functions/index.js
@@ -42,7 +42,9 @@ exports.createFirebaseTFLiteModel = functions.storage.object().onFinalize(async 
   // [START stopConditions]
   // Exit if this is triggered on a file that is not a tflite file
   if (!filePath.endsWith('.tflite')) {
-    return console.log(`Content type is: ${contentType}. This is not a TFLite file.`);
+    return functions.logger.log(
+      `Content type is: ${contentType}. This is not a TFLite file.`
+    );
   }
   // [END stopConditions]
 
@@ -53,7 +55,7 @@ exports.createFirebaseTFLiteModel = functions.storage.object().onFinalize(async 
   const re = /^[A-Za-z\d_-]{1,32}$/;
   if (!re.test(modelName)) {
     const errMsg = "Model name must be 1 to 32 characters long, and may only consist of alphanumeric characters, underscores, and hyphens.";
-    return console.log(`Not creating model '${modelName}'. ${errMsg}`);
+    return functions.logger.log(`Not creating model '${modelName}'. ${errMsg}`);
   }
 
   const gcsUri = `gs://${fileBucket}/${filePath}`;
@@ -76,7 +78,9 @@ exports.createFirebaseTFLiteModel = functions.storage.object().onFinalize(async 
       model = await ml.updateModel(existingModel.modelId, modelOptions);
     } else {
       // For safety - don't overwrite (update) Firebase Models that were created a different way.
-      return console.log("Not updating existing model with same name. Existing model was created from a different source location.");
+      return functions.logger.log(
+        'Not updating existing model with same name. Existing model was created from a different source location.'
+      );
     }
   } else {
 	  model = await ml.createModel(modelOptions);
@@ -84,10 +88,14 @@ exports.createFirebaseTFLiteModel = functions.storage.object().onFinalize(async 
 
   if (model.validationError) {
     // Can't publish models with validation errors
-    return console.log(`Validation error: ${model.validationError}. Will not publish the model.`);
+    return functions.logger.log(
+      `Validation error: ${model.validationError}. Will not publish the model.`
+    );
   }
 
   const publishedModel = await ml.publishModel(model.modelId);
-  return console.log(`Model ${modelName} published at ${publishedModel.updateTime}.`)
+  return functions.logger.log(
+    `Model ${modelName} published at ${publishedModel.updateTime}.`
+  );
 });
 // [END publishModel]

--- a/quickstarts/email-users/functions/index.js
+++ b/quickstarts/email-users/functions/index.js
@@ -78,7 +78,7 @@ async function sendWelcomeEmail(email, displayName) {
   mailOptions.subject = `Welcome to ${APP_NAME}!`;
   mailOptions.text = `Hey ${displayName || ''}! Welcome to ${APP_NAME}. I hope you will enjoy our service.`;
   await mailTransport.sendMail(mailOptions);
-  console.log('New welcome email sent to:', email);
+  functions.logger.log('New welcome email sent to:', email);
   return null;
 }
 
@@ -93,6 +93,6 @@ async function sendGoodbyeEmail(email, displayName) {
   mailOptions.subject = `Bye!`;
   mailOptions.text = `Hey ${displayName || ''}!, We confirm that we have deleted your ${APP_NAME} account.`;
   await mailTransport.sendMail(mailOptions);
-  console.log('Account deletion confirmation email sent to:', email);
+  functions.logger.log('Account deletion confirmation email sent to:', email);
   return null;
 }

--- a/quickstarts/pubsub-helloworld/functions/index.js
+++ b/quickstarts/pubsub-helloworld/functions/index.js
@@ -32,7 +32,7 @@ exports.helloPubSub = functions.pubsub.topic('topic-name').onPublish((message) =
   const messageBody = message.data ? Buffer.from(message.data, 'base64').toString() : null;
   // [END readBase64]
   // Print the message in the logs.
-  console.log(`Hello ${messageBody || 'World'}!`);
+  functions.logger.log(`Hello ${messageBody || 'World'}!`);
   return null;
 });
 // [END helloWorld]
@@ -48,11 +48,11 @@ exports.helloPubSubJson = functions.pubsub.topic('another-topic-name').onPublish
   try {
     name = message.json.name;
   } catch (e) {
-    console.error('PubSub message was not JSON', e);
+    functions.logger.error('PubSub message was not JSON', e);
   }
   // [END readJson]
   // Print the message in the logs.
-  console.log(`Hello ${name || 'World'}!`);
+  functions.logger.log(`Hello ${name || 'World'}!`);
   return null;
 });
 
@@ -66,6 +66,6 @@ exports.helloPubSubAttributes = functions.pubsub.topic('yet-another-topic-name')
   const name = message.attributes.name;
   // [END readAttributes]
   // Print the message in the logs.
-  console.log(`Hello ${name || 'World'}!`);
+  functions.logger.log(`Hello ${name || 'World'}!`);
   return null;
 });

--- a/quickstarts/test-complete/functions/index.js
+++ b/quickstarts/test-complete/functions/index.js
@@ -5,8 +5,9 @@ exports.logTestComplete = functions.testLab
   .onComplete(testMatrix => {
     const { testMatrixId, createTime, state, outcomeSummary } = testMatrix;
 
-    console.log(
-      `TEST ${testMatrixId} (created at ${createTime}): ${state}. ${outcomeSummary ||
-        ''}`
+    functions.logger.log(
+      `TEST ${testMatrixId} (created at ${createTime}): ${state}. ${
+        outcomeSummary || ''
+      }`
     );
   });

--- a/quickstarts/thumbnails/functions/index.js
+++ b/quickstarts/thumbnails/functions/index.js
@@ -43,14 +43,14 @@ exports.generateThumbnail = functions.storage.object().onFinalize(async (object)
   // [START stopConditions]
   // Exit if this is triggered on a file that is not an image.
   if (!contentType.startsWith('image/')) {
-    return console.log('This is not an image.');
+    return functions.logger.log('This is not an image.');
   }
 
   // Get the file name.
   const fileName = path.basename(filePath);
   // Exit if the image is already a thumbnail.
   if (fileName.startsWith('thumb_')) {
-    return console.log('Already a Thumbnail.');
+    return functions.logger.log('Already a Thumbnail.');
   }
   // [END stopConditions]
 
@@ -62,10 +62,10 @@ exports.generateThumbnail = functions.storage.object().onFinalize(async (object)
     contentType: contentType,
   };
   await bucket.file(filePath).download({destination: tempFilePath});
-  console.log('Image downloaded locally to', tempFilePath);
+  functions.logger.log('Image downloaded locally to', tempFilePath);
   // Generate a thumbnail using ImageMagick.
   await spawn('convert', [tempFilePath, '-thumbnail', '200x200>', tempFilePath]);
-  console.log('Thumbnail created at', tempFilePath);
+  functions.logger.log('Thumbnail created at', tempFilePath);
   // We add a 'thumb_' prefix to thumbnails file name. That's where we'll upload the thumbnail.
   const thumbFileName = `thumb_${fileName}`;
   const thumbFilePath = path.join(path.dirname(filePath), thumbFileName);

--- a/quickstarts/time-server/functions/index.js
+++ b/quickstarts/time-server/functions/index.js
@@ -70,7 +70,7 @@ exports.date = functions.https.onRequest((req, res) => {
     }
     // [START sendResponse]
     const formattedDate = moment().format(`${format}`);
-    console.log('Sending Formatted date:', formattedDate);
+    functions.logger.log('Sending Formatted date:', formattedDate);
     res.status(200).send(formattedDate);
     // [END sendResponse]
   });

--- a/quickstarts/uppercase/functions/index.js
+++ b/quickstarts/uppercase/functions/index.js
@@ -49,7 +49,7 @@ exports.makeUppercase = functions.database.ref('/messages/{pushId}/original')
     .onCreate((snapshot, context) => {
       // Grab the current value of what was written to the Realtime Database.
       const original = snapshot.val();
-      console.log('Uppercasing', context.params.pushId, original);
+      functions.logger.log('Uppercasing', context.params.pushId, original);
       const uppercase = original.toUpperCase();
       // You must return a Promise when performing asynchronous tasks inside a Functions such as
       // writing to the Firebase Realtime Database.

--- a/remote-config-diff/functions/index.js
+++ b/remote-config-diff/functions/index.js
@@ -25,11 +25,11 @@ exports.showConfigDiff = functions.remoteConfig.onUpdate(versionMetadata => {
 
       const diff = jsonDiff.diffString(previousTemplate, currentTemplate);
 
-      console.log(diff);
+      functions.logger.log(diff);
 
       return null;
     }).catch(error => {
-      console.error(error);
+      functions.logger.error(error);
       return null;
     });
 });
@@ -49,7 +49,7 @@ function getTemplate(version, accessToken) {
   return rp(options).then(resp => {
     return Promise.resolve(resp);
   }).catch(err => {
-    console.error(err);
+    functions.logger.error(err);
     return Promise.resolve(null);
   });
 }

--- a/stripe/functions/index.js
+++ b/stripe/functions/index.js
@@ -111,7 +111,7 @@ exports.createStripePayment = functions.firestore
     } catch (error) {
       // We want to capture errors and render them in a user-friendly way, while
       // still logging an exception with StackDriver
-      console.log(error);
+      functions.logger.log(error);
       await snap.ref.set({ error: userFacingMessage(error) }, { merge: true });
       await reportError(error, { user: context.params.userId });
     }
@@ -164,7 +164,7 @@ exports.cleanupUser = functions.auth.user().onDelete(async (user) => {
 
 /**
  * To keep on top of errors, we should raise a verbose error report with Stackdriver rather
- * than simply relying on console.error. This will calculate users affected + send you email
+ * than simply relying on functions.logger.error. This will calculate users affected + send you email
  * alerts, if you've opted into receiving them.
  */
 

--- a/survey-app-update/functions/index.js
+++ b/survey-app-update/functions/index.js
@@ -65,5 +65,5 @@ async function sendSurveyEmail(email, name) {
   };
 
   await mailTransport.sendMail(mailOptions);
-  console.log('Upgrade App Survey email sent to:', email);
+  functions.logger.log('Upgrade App Survey email sent to:', email);
 }

--- a/template-handlebars/functions/firebaseUser.js
+++ b/template-handlebars/functions/firebaseUser.js
@@ -24,7 +24,7 @@ const cookieParser = require('cookie-parser')();
 // `Authorization: Bearer <Firebase ID Token>`.
 // When decoded successfully, the ID Token content will be added as `req.user`.
 async function validateFirebaseIdToken (req, res, next) {
-  console.log('Check if request is authorized with Firebase ID token');
+  functions.logger.log('Check if request is authorized with Firebase ID token');
 
   const idToken = await getIdTokenFromRequest(req, res);
   if (idToken) {
@@ -38,14 +38,14 @@ async function validateFirebaseIdToken (req, res, next) {
  */
 function getIdTokenFromRequest(req, res) {
   if (req.headers.authorization && req.headers.authorization.startsWith('Bearer ')) {
-    console.log('Found "Authorization" header');
+    functions.logger.log('Found "Authorization" header');
     // Read the ID Token from the Authorization header.
     return Promise.resolve(req.headers.authorization.split('Bearer ')[1]);
   }
   return new Promise((resolve, reject) => {
     cookieParser(req, res, () => {
       if (req.cookies && req.cookies.__session) {
-        console.log('Found "__session" cookie');
+        functions.logger.log('Found "__session" cookie');
         // Read the ID Token from cookie.
         resolve(req.cookies.__session);
       } else {
@@ -62,9 +62,9 @@ async function addDecodedIdTokenToRequest(idToken, req) {
   try {
     const decodedIdToken = await admin.auth().verifyIdToken(idToken);
     req.user = decodedIdToken;
-    console.log('ID Token correctly decoded', decodedIdToken);
+    functions.logger.log('ID Token correctly decoded', decodedIdToken);
   } catch (error) {
-    console.error('Error while verifying Firebase ID token:', error);
+    functions.logger.error('Error while verifying Firebase ID token:', error);
   }
 }
 

--- a/template-handlebars/functions/firebaseUser.js
+++ b/template-handlebars/functions/firebaseUser.js
@@ -17,6 +17,7 @@
 
 const admin = require('firebase-admin');
 const cookieParser = require('cookie-parser')();
+const functions = require('firebase-functions');
 
 // Express middleware that checks if a Firebase ID Tokens is passed in the `Authorization` HTTP
 // header or the `__session` cookie and decodes it.

--- a/template-handlebars/functions/index.js
+++ b/template-handlebars/functions/index.js
@@ -32,7 +32,7 @@ app.get('/', (req, res) => {
   // @ts-ignore
   const user = req.user;
 
-  console.log('Signed-in user:', user);
+  functions.logger.log('Signed-in user:', user);
   return res.render('user', {
     user: user,
   });

--- a/testlab-to-slack/functions/index.js
+++ b/testlab-to-slack/functions/index.js
@@ -70,5 +70,5 @@ exports.postTestResultsToSlack = functions.testLab
 
     const slackResponse = await postToSlack(title, details);
 
-    console.log(JSON.stringify(slackResponse.data));
+    functions.logger.log(JSON.stringify(slackResponse.data));
   });

--- a/text-moderation/functions/index.js
+++ b/text-moderation/functions/index.js
@@ -26,13 +26,16 @@ exports.moderator = functions.database.ref('/messages/{messageId}').onWrite((cha
 
   if (message && !message.sanitized) {
     // Retrieved the message values.
-    console.log('Retrieved message content: ', message);
+    functions.logger.log('Retrieved message content: ', message);
 
     // Run moderation checks on on the message and moderate if needed.
     const moderatedMessage = moderateMessage(message.text);
 
     // Update the Firebase DB with checked message.
-    console.log('Message has been moderated. Saving to DB: ', moderatedMessage);
+    functions.logger.log(
+      'Message has been moderated. Saving to DB: ',
+      moderatedMessage
+    );
     return change.after.ref.update({
       text: moderatedMessage,
       sanitized: true,
@@ -46,13 +49,13 @@ exports.moderator = functions.database.ref('/messages/{messageId}').onWrite((cha
 function moderateMessage(message) {
   // Re-capitalize if the user is Shouting.
   if (isShouting(message)) {
-    console.log('User is shouting. Fixing sentence case...');
+    functions.logger.log('User is shouting. Fixing sentence case...');
     message = stopShouting(message);
   }
 
   // Moderate if the user uses SwearWords.
   if (containsSwearwords(message)) {
-    console.log('User is swearing. moderating...');
+    functions.logger.log('User is swearing. moderating...');
     message = moderateSwearwords(message);
   }
 

--- a/username-password-auth/functions/index.js
+++ b/username-password-auth/functions/index.js
@@ -43,17 +43,20 @@ const basicAuthRequest = require('request');
  */
 exports.auth = functions.https.onRequest((req, res) => {
   const handleError = (username, error) => {
-    console.error({User: username}, error);
+    functions.logger.error({ User: username }, error);
     return res.sendStatus(500);
   };
 
   const handleResponse = (username, status, body) => {
-    console.log({User: username}, {
-      Response: {
-        Status: status,
-        Body: body,
-      },
-    });
+    functions.logger.log(
+      { User: username },
+      {
+        Response: {
+          Status: status,
+          Body: body,
+        },
+      }
+    );
     if (body) {
       return res.status(200).json(body);
     }


### PR DESCRIPTION
Use the [functions logger SDK recommended in the docs](https://firebase.google.com/docs/functions/writing-and-viewing-logs?hl=en#logger-sdk) instead of `console.log`.

I did a find+replace and did my best to catch edge cases:

- any in-browser JS needs to keep `console.log`
- links to the firebase console (`https://console.firebase.google.com`) shouldn't be changed to `https://functions.logger.firebase.google.com` 😆 