### PR TITLE
Fix ffmpeg path access

### DIFF
--- a/ffmpeg-convert-audio/functions/index.js
+++ b/ffmpeg-convert-audio/functions/index.js
@@ -68,7 +68,7 @@ exports.generateMonoAudio = functions.storage.object().onFinalize(async (object)
   // Convert the audio to mono channel using FFMPEG.
 
   let command = ffmpeg(tempFilePath)
-      .setFfmpegPath(ffmpeg_static.path)
+      .setFfmpegPath(ffmpeg_static)
       .audioChannels(1)
       .audioFrequency(16000)
       .format('flac')


### PR DESCRIPTION
I tried running this function to convert audio files to the .flac format and received an error that the ffmpeg path was not found. It appears as if the `ffmpeg_static.path` should actually be `ffmpeg_static` as mentioned here in the [documentation](https://www.npmjs.com/package/ffmpeg-static). 

I've verified that this change works and actually does help convert audio files to .flac. 

Please let me know if I need to do anything else for this pull request and thank you for the awesome samples! They really help accelerate projects. 