### PR TITLE
Improve cookie issues in Instragram & LinkedIn samples

### DIFF
--- a/instagram-auth/firebase.json
+++ b/instagram-auth/firebase.json
@@ -3,6 +3,16 @@
     "rules": "database.rules.json"
   },
   "hosting": {
-    "public": "public"
+    "public": "public",
+    "rewrites": [
+      {
+        "source": "/redirect",
+        "function": "redirect"
+      },
+      {
+        "source": "/token",
+        "function": "token"
+      }
+    ]
   }
 }

--- a/instagram-auth/public/popup.html
+++ b/instagram-auth/public/popup.html
@@ -68,14 +68,14 @@ Please wait...
     document.body.innerText = 'Error back from the Instagram auth page: ' + error;
   } else if(!code) {
     // Start the auth flow.
-    window.location.href  = 'https://us-central1-' + getFirebaseProjectId() + '.cloudfunctions.net/redirect';
+    window.location.href  = '/redirect';
   } else {
     // Use JSONP to load the 'token' Firebase Function to exchange the auth code against a Firebase custom token.
     const script = document.createElement('script');
     script.type = 'text/javascript';
     // This is the URL to the HTTP triggered 'token' Firebase Function.
     // See https://firebase.google.com/docs/functions.
-    var tokenFunctionURL = 'https://us-central1-' + getFirebaseProjectId() + '.cloudfunctions.net/token';
+    var tokenFunctionURL = '/token';
     script.src = tokenFunctionURL +
         '?code=' + encodeURIComponent(code) +
         '&state=' + encodeURIComponent(state) +

--- a/linkedin-auth/firebase.json
+++ b/linkedin-auth/firebase.json
@@ -3,6 +3,16 @@
     "rules": "database.rules.json"
   },
   "hosting": {
-    "public": "public"
+    "public": "public",
+    "rewrites": [
+      {
+        "source": "/redirect",
+        "function": "redirect"
+      },
+      {
+        "source": "/token",
+        "function": "token"
+      }
+    ]
   }
 }

--- a/linkedin-auth/public/popup.html
+++ b/linkedin-auth/public/popup.html
@@ -68,14 +68,14 @@ Please wait...
     document.body.innerText = 'Error back from the LinkedIn auth page: ' + error;
   } else if(!code) {
     // Start the auth flow.
-    window.location.href  = 'https://us-central1-' + getFirebaseProjectId() + '.cloudfunctions.net/redirect';
+    window.location.href  = '/redirect';
   } else {
     // Use JSONP to load the 'token' Firebase Function to exchange the auth code against a Firebase custom token.
     const script = document.createElement('script');
     script.type = 'text/javascript';
     // This is the URL to the HTTP triggered 'token' Firebase Function.
     // See https://firebase.google.com/docs/functions.
-    var tokenFunctionURL = 'https://us-central1-' + getFirebaseProjectId() + '.cloudfunctions.net/token';
+    var tokenFunctionURL = '/token';
     script.src = tokenFunctionURL +
         '?code=' + encodeURIComponent(code) +
         '&state=' + encodeURIComponent(state) +


### PR DESCRIPTION
Makes cookies first party by running the Firebase functions 'redirect' & 'token' through the same domain as the Firebase Hosting site. Similar idea to #826 but without changing the cookies to SameSite:None.