### PR TITLE
fix: last sign in time

### DIFF
--- a/delete-unused-accounts-cron/functions/index.js
+++ b/delete-unused-accounts-cron/functions/index.js
@@ -69,7 +69,7 @@ async function getInactiveUsers(users = [], nextPageToken) {
   const result = await admin.auth().listUsers(1000, nextPageToken);
   // Find users that have not signed in in the last 30 days.
   const inactiveUsers = result.users.filter(
-      user => Date.parse(user.metadata.lastRefreshTime ?? user.metadata.lastSignInTime) < (Date.now() - 30 * 24 * 60 * 60 * 1000));
+      user => Date.parse(user.metadata.lastRefreshTime || user.metadata.lastSignInTime) < (Date.now() - 30 * 24 * 60 * 60 * 1000));
   
   // Concat with list of previously found inactive users if there was more than 1000 users.
   users = users.concat(inactiveUsers);

--- a/delete-unused-accounts-cron/functions/index.js
+++ b/delete-unused-accounts-cron/functions/index.js
@@ -69,7 +69,7 @@ async function getInactiveUsers(users = [], nextPageToken) {
   const result = await admin.auth().listUsers(1000, nextPageToken);
   // Find users that have not signed in in the last 30 days.
   const inactiveUsers = result.users.filter(
-      user => Date.parse(user.metadata.lastSignInTime) < (Date.now() - 30 * 24 * 60 * 60 * 1000));
+      user => Date.parse(user.metadata.lastRefreshTime ?? user.metadata.lastSignInTime) < (Date.now() - 30 * 24 * 60 * 60 * 1000));
   
   // Concat with list of previously found inactive users if there was more than 1000 users.
   users = users.concat(inactiveUsers);


### PR DESCRIPTION
I've changed detection mechanism of inactive users because `user.metadata.lastSignInTime` returns the date the user last signed in and only updated when user manually logs out and signs in again. That leads to deletion of active users. So `user.metadata.lastRefreshTime` should be used instead, it returns the time at which the user was last active but could be null if user wasn't active at all, so we still should get `user.metadata.lastSignInTime`. Related issue #829 