### PR TITLE
Fix for delete-unused-accounts-cron example

### DIFF
--- a/delete-unused-accounts-cron/functions/index.js
+++ b/delete-unused-accounts-cron/functions/index.js
@@ -18,7 +18,7 @@
 const functions = require('firebase-functions');
 const admin = require('firebase-admin');
 admin.initializeApp();
-const PromisePool = require('es6-promise-pool').default;
+const PromisePool = require('es6-promise-pool');
 // Maximum concurrent account deletions.
 const MAX_CONCURRENT = 3;
 


### PR DESCRIPTION
Running this example results in TypeError: PromisePool is not a constructor.

Changed
``const PromisePool = require('es6-promise-pool').default;``
to
``const PromisePool = require('es6-promise-pool');``

This change fixes the abovementioned error.