### PR TITLE
Update `ecmaVersion` to 2020 to support optional chaining operator.

### DIFF
--- a/authenticated-json-api/functions/.eslintrc.json
+++ b/authenticated-json-api/functions/.eslintrc.json
@@ -1,7 +1,7 @@
 {
   "parserOptions": {
     // Required for certain syntax usages
-    "ecmaVersion": 2017
+    "ecmaVersion": 2020
   },
   "plugins": [
     "promise"


### PR DESCRIPTION
This fixes a lint problem introduced by #943.

```
$ npm run lint
[...]
firebase/functions-samples/authenticated-json-api/functions/index.js
  95:33  error  Parsing error: Unexpected token .
```

