### PR TITLE
Update tq sample to reflect now obsolete limitation of 2nd Gen function

### DIFF
--- a/2nd-gen/taskqueues-backup-images/functions/package.json
+++ b/2nd-gen/taskqueues-backup-images/functions/package.json
@@ -18,7 +18,6 @@
   "dependencies": {
     "firebase-admin": "^11.5.0",
     "firebase-functions": "^4.2.1",
-    "google-auth-library": "^8.6.0",
     "node-fetch": "^2.6.7"
   },
   "devDependencies": {


### PR DESCRIPTION
We no longer need to get URL for CF3 2nd Gen function - they now expose a deterministic URL. 