### PR TITLE
Add codebases for all 2nd gen Node samples

### DIFF
--- a/Node/alerts-to-discord/firebase.json
+++ b/Node/alerts-to-discord/firebase.json
@@ -1,5 +1,6 @@
 {
   "functions": {
+    "codebase": "alerts-to-discord",
     "predeploy": [
       "npm --prefix \"$RESOURCE_DIR\" run lint"
     ]

--- a/Node/app-distribution-feedback-to-jira/firebase.json
+++ b/Node/app-distribution-feedback-to-jira/firebase.json
@@ -2,7 +2,7 @@
   "functions": [
     {
       "source": "functions",
-      "codebase": "default",
+      "codebase": "app-distribution-feedback-to-jira",
       "ignore": [
         "node_modules",
         ".git",

--- a/Node/delete-unused-accounts-cron/firebase.json
+++ b/Node/delete-unused-accounts-cron/firebase.json
@@ -1,1 +1,5 @@
-{}
+{
+    "functions": {
+        "codebase": "delete-unused-accounts-cron"
+    }
+}

--- a/Node/instrument-with-opentelemetry/firebase.json
+++ b/Node/instrument-with-opentelemetry/firebase.json
@@ -1,6 +1,7 @@
 {
   "functions": {
-    "source": "functions"
+    "source": "functions",
+    "codebase": "instrument-with-opentelemetry"
   },
   "emulators": {
     "functions": {

--- a/Node/quickstarts/auth-blocking-functions/firebase.json
+++ b/Node/quickstarts/auth-blocking-functions/firebase.json
@@ -1,5 +1,6 @@
 {
   "functions": {
+    "codebase": "auth-blocking-functions",
     "predeploy": [
       "npm --prefix \"$RESOURCE_DIR\" run lint"
     ]

--- a/Node/quickstarts/callable-functions/firebase.json
+++ b/Node/quickstarts/callable-functions/firebase.json
@@ -1,5 +1,6 @@
 {
   "functions": {
+    "codebase": "callable-functions",
     "predeploy": [
       "npm --prefix \"$RESOURCE_DIR\" run lint"
     ]

--- a/Node/quickstarts/custom-events/firebase.json
+++ b/Node/quickstarts/custom-events/firebase.json
@@ -1,5 +1,6 @@
 {
   "functions": {
+    "codebase": "custom-events",
     "predeploy": [
       "npm --prefix \"$RESOURCE_DIR\" run lint"
     ]

--- a/Node/quickstarts/https-time-server/firebase.json
+++ b/Node/quickstarts/https-time-server/firebase.json
@@ -1,5 +1,6 @@
 {
   "functions": {
+    "codebase": "https-time-server",
     "predeploy": [
       "npm --prefix \"$RESOURCE_DIR\" run lint"
     ]

--- a/Node/quickstarts/monitor-cloud-logging/firebase.json
+++ b/Node/quickstarts/monitor-cloud-logging/firebase.json
@@ -2,7 +2,7 @@
   "functions": [
     {
       "source": "functions",
-      "codebase": "default",
+      "codebase": "monitor-cloud-logging",
       "ignore": [
         "node_modules",
         ".git",

--- a/Node/quickstarts/pubsub-helloworld/firebase.json
+++ b/Node/quickstarts/pubsub-helloworld/firebase.json
@@ -1,5 +1,6 @@
 {
   "functions": {
+    "codebase": "pubsub-helloworld",
     "predeploy": [
       "npm --prefix \"$RESOURCE_DIR\" run lint"
     ]

--- a/Node/quickstarts/testlab-matrix-completed/firebase.json
+++ b/Node/quickstarts/testlab-matrix-completed/firebase.json
@@ -1,1 +1,5 @@
-{}
+{
+  "functions": {
+    "codebase": "testlab-matrix-completed"
+  }
+}

--- a/Node/quickstarts/thumbnails/firebase.json
+++ b/Node/quickstarts/thumbnails/firebase.json
@@ -1,5 +1,6 @@
 {
   "functions": {
+    "codebase": "thumbnails",
     "predeploy": [
       "npm --prefix \"$RESOURCE_DIR\" run lint"
     ]

--- a/Node/quickstarts/uppercase-firestore/firebase.json
+++ b/Node/quickstarts/uppercase-firestore/firebase.json
@@ -1,4 +1,7 @@
 {
+  "functions": {
+    "codebase": "uppercase-firestore"
+  },
   "firestore": {
     "rules": "firestore.rules",
     "indexes": "firestore.indexes.json"

--- a/Node/quickstarts/uppercase-rtdb/firebase.json
+++ b/Node/quickstarts/uppercase-rtdb/firebase.json
@@ -1,4 +1,7 @@
 {
+  "functions": {
+    "codebase": "uppercase-rtdb"
+  },
   "rulesFile": "database.rules.json",
   "emulators": {
     "functions": {

--- a/Node/remote-config-diff/firebase.json
+++ b/Node/remote-config-diff/firebase.json
@@ -1,1 +1,5 @@
-{}
+{
+  "functions": {
+    "codebase": "remote-config-diff"
+  }
+}

--- a/Node/taskqueues-backup-images/firebase.json
+++ b/Node/taskqueues-backup-images/firebase.json
@@ -1,1 +1,5 @@
-{}
+{
+  "functions": {
+    "codebase": "taskqueues-backup-images"
+  }
+}

--- a/Node/test-functions-jest-ts/firebase.json
+++ b/Node/test-functions-jest-ts/firebase.json
@@ -1,5 +1,6 @@
 {
   "functions": {
+    "codebase": "test-functions-jest-ts",
     "predeploy": [
       "npm --prefix \"$RESOURCE_DIR\" run lint",
       "npm --prefix \"$RESOURCE_DIR\" run build"

--- a/Node/test-functions-jest/firebase.json
+++ b/Node/test-functions-jest/firebase.json
@@ -1,5 +1,6 @@
 {
   "functions": {
+    "codebase": "test-functions-jest",
     "predeploy": [
       "npm --prefix \"$RESOURCE_DIR\" run lint"
     ],

--- a/Node/test-functions-mocha/firebase.json
+++ b/Node/test-functions-mocha/firebase.json
@@ -1,5 +1,6 @@
 {
   "functions": {
+    "codebase": "test-functions-mocha",
     "predeploy": [
       "npm --prefix \"$RESOURCE_DIR\" run lint"
     ],

--- a/Node/testlab-to-slack/firebase.json
+++ b/Node/testlab-to-slack/firebase.json
@@ -1,1 +1,5 @@
-{}
+{
+  "functions": {
+    "codebase": "testlab-to-slack"
+  }
+}


### PR DESCRIPTION
This makes it easier to deploy samples without affecting the default Cloud Functions codebase of a project.

Only Node 2nd gen for now because (1) there are a LOT of 1st-gen samples, and (2) Python directory needs some rearranging before it is ready for `firebase.json` files