### PR TITLE
feat: use faster profanity checker

### DIFF
--- a/Node-1st-gen/text-moderation/functions/index.js
+++ b/Node-1st-gen/text-moderation/functions/index.js
@@ -13,73 +13,64 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
+"use strict";
 
-const functions = require('firebase-functions/v1');
-const capitalizeSentence = require('capitalize-sentence');
-const Filter = require('bad-words');
-const badWordsFilter = new Filter();
+const functions = require("firebase-functions/v1");
+const capitalizeSentence = require("capitalize-sentence");
+const { isProfane, replaceProfanities } = import("no-profanity");
 
 // Moderates messages by lowering all uppercase messages and removing swearwords.
-exports.moderator = functions.database.ref('/messages/{messageId}').onWrite((change) => {
-  const message = change.after.val();
+exports.moderator = functions.database.ref("/messages/{messageId}").onWrite((change) => {
+    const message = change.after.val();
 
-  if (message && !message.sanitized) {
-    // Retrieved the message values.
-    functions.logger.log('Retrieved message content: ', message);
+    if (message && !message.sanitized) {
+        // Retrieved the message values.
+        functions.logger.log("Retrieved message content: ", message);
 
-    // Run moderation checks on on the message and moderate if needed.
-    const moderatedMessage = moderateMessage(message.text);
+        // Run moderation checks on on the message and moderate if needed.
+        const moderatedMessage = moderateMessage(message.text);
 
-    // Update the Firebase DB with checked message.
-    functions.logger.log(
-      'Message has been moderated. Saving to DB: ',
-      moderatedMessage
-    );
-    return change.after.ref.update({
-      text: moderatedMessage,
-      sanitized: true,
-      moderated: message.text !== moderatedMessage,
-    });
-  }
-  return null;
+        // Update the Firebase DB with checked message.
+        functions.logger.log("Message has been moderated. Saving to DB: ", moderatedMessage);
+        return change.after.ref.update({
+            text: moderatedMessage,
+            sanitized: true,
+            moderated: message.text !== moderatedMessage,
+        });
+    }
+    return null;
 });
 
 // Moderates the given message if appropriate.
 function moderateMessage(message) {
-  // Re-capitalize if the user is Shouting.
-  if (isShouting(message)) {
-    functions.logger.log('User is shouting. Fixing sentence case...');
-    message = stopShouting(message);
-  }
+    // Re-capitalize if the user is Shouting.
+    if (isShouting(message)) {
+        functions.logger.log("User is shouting. Fixing sentence case...");
+        message = stopShouting(message);
+    }
 
-  // Moderate if the user uses SwearWords.
-  if (containsSwearwords(message)) {
-    functions.logger.log('User is swearing. moderating...');
-    message = moderateSwearwords(message);
-  }
+    // Moderate if the user uses SwearWords.
+    if (isProfane(message)) {
+        functions.logger.log("User is swearing. moderating...");
+        message = moderateSwearwords(message);
+    }
 
-  return message;
-}
-
-// Returns true if the string contains swearwords.
-function containsSwearwords(message) {
-  return message !== badWordsFilter.clean(message);
+    return message;
 }
 
 // Hide all swearwords. e.g: Crap => ****.
 function moderateSwearwords(message) {
-  return badWordsFilter.clean(message);
+    return replaceProfanities(message);
 }
 
 // Detect if the current message is shouting. i.e. there are too many Uppercase
 // characters or exclamation points.
 function isShouting(message) {
-  return message.replace(/[^A-Z]/g, '').length > message.length / 2 || message.replace(/[^!]/g, '').length >= 3;
+    return message.replace(/[^A-Z]/g, "").length > message.length / 2 || message.replace(/[^!]/g, "").length >= 3;
 }
 
 // Correctly capitalize the string as a sentence (e.g. uppercase after dots)
 // and remove exclamation points.
 function stopShouting(message) {
-  return capitalizeSentence(message.toLowerCase()).replace(/!+/g, '.');
+    return capitalizeSentence(message.toLowerCase()).replace(/!+/g, ".");
 }

--- a/Node-1st-gen/text-moderation/functions/package.json
+++ b/Node-1st-gen/text-moderation/functions/package.json
@@ -2,10 +2,10 @@
   "name": "text-moderation-functions",
   "description": "Moderate text using Firebase Functions",
   "dependencies": {
-    "bad-words": "^3.0.4",
     "capitalize-sentence": "^0.1.5",
     "firebase-admin": "^11.9.0",
-    "firebase-functions": "^4.4.1"
+    "firebase-functions": "^4.4.1",
+    "no-profanity": "^1.1.5"
   },
   "devDependencies": {
     "eslint": "^8.40.0"

--- a/Node/quickstarts/callable-functions/functions/package.json
+++ b/Node/quickstarts/callable-functions/functions/package.json
@@ -16,10 +16,10 @@
   },
   "main": "index.js",
   "dependencies": {
-    "bad-words": "^3.0.4",
     "capitalize-sentence": "^0.1.5",
     "firebase-admin": "^11.9.0",
-    "firebase-functions": "^4.4.1"
+    "firebase-functions": "^4.4.1",
+    "no-profanity": "^1.1.5"
   },
   "devDependencies": {
     "eslint": "^8.40.0",

--- a/Node/quickstarts/callable-functions/functions/sanitizer.js
+++ b/Node/quickstarts/callable-functions/functions/sanitizer.js
@@ -16,34 +16,24 @@
 "use strict";
 
 const capitalizeSentence = require("capitalize-sentence");
-const Filter = require("bad-words");
-const badWordsFilter = new Filter();
+const { isProfane, replaceProfanities } = import("no-profanity");
 
 // Sanitizes the given text if needed by replacing bad words with '*'.
 exports.sanitizeText = (text) => {
-  // Re-capitalize if the user is Shouting.
-  if (isShouting(text)) {
-    console.log("User is shouting. Fixing sentence case...");
-    text = stopShouting(text);
-  }
+    // Re-capitalize if the user is Shouting.
+    if (isShouting(text)) {
+        console.log("User is shouting. Fixing sentence case...");
+        text = stopShouting(text);
+    }
 
-  // Moderate if the user uses SwearWords.
-  if (containsSwearwords(text)) {
-    console.log("User is swearing. moderating...");
-    text = replaceSwearwords(text);
-  }
+    // Moderate if the user uses SwearWords.
+    if (isProfane(text)) {
+        console.log("User is swearing. moderating...");
+        text = replaceSwearwords(text);
+    }
 
-  return text;
+    return text;
 };
-
-/**
- * Returns true if the string contains swearwords.
- * @param {string} message
- * @return {boolean}
- */
-function containsSwearwords(message) {
-  return message !== badWordsFilter.clean(message);
-}
 
 /**
  * Hide all swearwords. e.g: Crap => ****.
@@ -51,7 +41,7 @@ function containsSwearwords(message) {
  * @return {string}
  */
 function replaceSwearwords(message) {
-  return badWordsFilter.clean(message);
+    return replaceProfanities(message);
 }
 
 /**
@@ -61,8 +51,7 @@ function replaceSwearwords(message) {
  * @return {boolean}
  */
 function isShouting(message) {
-  return message.replace(/[^A-Z]/g, "").length > message.length / 2 ||
-   message.replace(/[^!]/g, "").length >= 3;
+    return message.replace(/[^A-Z]/g, "").length > message.length / 2 || message.replace(/[^!]/g, "").length >= 3;
 }
 
 /**
@@ -72,5 +61,5 @@ function isShouting(message) {
  * @return {string} capitalized string
  */
 function stopShouting(message) {
-  return capitalizeSentence(message.toLowerCase()).replace(/!+/g, ".");
+    return capitalizeSentence(message.toLowerCase()).replace(/!+/g, ".");
 }


### PR DESCRIPTION
I've replaced the `bad-words` package with the `no-profanity` package as the bad-words package has not been updated for a few years and uses a for-loop to detect profanity instead of a single regex. This slows the package down significantly.

Furthermore, the no-profanity package contains more known profanities. So double benefit!