### PR TITLE
Bugfix : Ensure emailVerified is not set to true in Spotify Auth sample

### DIFF
--- a/Node-1st-gen/spotify-auth/functions/index.js
+++ b/Node-1st-gen/spotify-auth/functions/index.js
@@ -137,7 +137,7 @@ async function createFirebaseAccount(spotifyID, displayName, photoURL, email, ac
         displayName: displayName,
         photoURL: photoURL,
         email: email,
-        emailVerified: true,
+        emailVerified: false,
       });
     }
     throw error;


### PR DESCRIPTION
### Problem
In the Spotify Auth sample, `customToken.emailVerified` was incorrectly set to true by default.
However, Spotify API does not verify user emails. This creates a potential security vulnerability.

### Solution
- Updated `functions/index.js` to ensure `emailVerified` is either unset or explicitly set to false.
- Tested the flow to confirm that emailVerified is not marked as true.

### Reference
Fixes #1154