### PR TITLE
feat: Add Dart sample for https-time-server

### DIFF
--- a/.github/workflows/test_dart.yml
+++ b/.github/workflows/test_dart.yml
@@ -36,10 +36,10 @@ jobs:
         dart-version:
           - "3.7.0"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Dart ${{ matrix.dart-version }}
-        uses: dart-lang/setup-dart@v1
+        uses: dart-lang/setup-dart@v1.6.0
         with:
           sdk: ${{ matrix.dart-version }}
 

--- a/.github/workflows/test_dart.yml
+++ b/.github/workflows/test_dart.yml
@@ -1,0 +1,56 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: CI Tests
+
+on:
+  pull_request:
+    paths:
+      - 'Dart/**'
+
+  push:
+    branches:
+      - main
+    paths:
+      - 'Dart/**'
+
+env:
+  CI: true
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        dart-version:
+          - "3.7.0"
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Dart ${{ matrix.dart-version }}
+        uses: dart-lang/setup-dart@v1
+        with:
+          sdk: ${{ matrix.dart-version }}
+
+      - name: HTTPS Time Server - Install dependencies
+        working-directory: ./Dart/quickstarts/https-time-server
+        run: dart pub get
+
+      - name: HTTPS Time Server - Format
+        working-directory: ./Dart/quickstarts/https-time-server
+        run: dart format --set-exit-if-changed .
+
+      - name: HTTPS Time Server - Analyze
+        working-directory: ./Dart/quickstarts/https-time-server
+        run: dart analyze .

--- a/.github/workflows/test_dart.yml
+++ b/.github/workflows/test_dart.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         dart-version:
-          - "3.7.0"
+          - "3.11.4"
     steps:
       - uses: actions/checkout@v4
 

--- a/Dart/quickstarts/https-time-server/.gitignore
+++ b/Dart/quickstarts/https-time-server/.gitignore
@@ -1,0 +1,5 @@
+.dart_tool/
+.packages
+build/
+*.dart_tool
+pubspec.lock

--- a/Dart/quickstarts/https-time-server/README.md
+++ b/Dart/quickstarts/https-time-server/README.md
@@ -16,7 +16,7 @@ Further reading:
 
 ### 1. Clone this repo
 
-Clone or download this repo and open the `quickstarts/time-server` directory.
+Clone or download this repo and open the `Dart/quickstarts/https-time-server` directory.
 
 
 ### 2. Create a Firebase project and configure the quickstart
@@ -67,21 +67,21 @@ Alteratively, you can call `firebase emulators:start` to test the functions on t
 
 After deploying the function, check the CLI's output to see the URL for your function.
 
-It will look something like: `https://<function-name>-<random-hash>-<region>.a.run.app`
+It will look something like: `https://<function-name>-<random-hash>.<region>.run.app`
 
 You can also send the format in the request body. For instance using cURL in the command line:
 
 ```bash
 curl -H 'Content-Type: application/json' /
      -d '{"format": "MMMM d yyyy, h:mm:ss a"}' /
-     <function url>/date
+     <function url>
 ```
 Formatted dates should be displayed.
 
 We are responding with a 403 error in case of PUT requests:
 
 ```bash
-curl -X PUT -d '{"format": "MMMM d yyyy, h:mm:ss a"}' <function-url>/date
+curl -X PUT -d '{"format": "MMMM d yyyy, h:mm:ss a"}' <function-url>
 ```
 
 

--- a/Dart/quickstarts/https-time-server/README.md
+++ b/Dart/quickstarts/https-time-server/README.md
@@ -1,0 +1,95 @@
+# Firebase SDK for Cloud Functions Quickstart - HTTPS trigger
+
+This quickstart demonstrates using the **Firebase SDK for Cloud Functions** with an HTTPS trigger through building an endpoint returning the current time.
+
+
+## Introduction
+
+The function `date` returns the current server date. You can pass it a `format` URL Query parameter to format the date.
+
+Further reading:
+
+ - [Read more about the Firebase SDK for Cloud Functions](https://firebase.google.com/docs/functions)
+
+
+## Initial setup, build tools and dependencies
+
+### 1. Clone this repo
+
+Clone or download this repo and open the `quickstarts/time-server` directory.
+
+
+### 2. Create a Firebase project and configure the quickstart
+
+Create a Firebase Project on the [Firebase Console](https://console.firebase.google.com).
+
+Set up your Firebase project by running `firebase use --add`, select your Project ID and follow the instructions.
+
+
+### 3. Install the Firebase CLI and enable Functions on your Firebase CLI
+
+You need to have installed the Firebase CLI. If you haven't run:
+
+```bash
+npm install -g firebase-tools
+```
+
+> Doesn't work? You may need to [change npm permissions](https://docs.npmjs.com/getting-started/fixing-npm-permissions).
+
+
+## Deploy the app to prod
+
+First you need to get the `dart` dependencies of the functions:
+
+```bash
+dart pub get
+```
+
+This installs locally:
+ - The Firebase Functions Dart SDK.
+ - The [intl](https://pub.dev/packages/intl) pub package to format time.
+
+Deploy to Firebase using the following command:
+
+```bash
+firebase deploy
+```
+
+This deploys and activates the date Function.
+
+> The first time you call `firebase deploy` on a new project with Functions will take longer than usual.
+
+
+Alteratively, you can call `firebase emulators:start` to test the functions on the local emulator suite.
+
+
+## Try the sample
+
+After deploying the function, check the CLI's output to see the URL for your function.
+
+It will look something like: `https://<function-name>-<random-hash>-<region>.a.run.app`
+
+You can also send the format in the request body. For instance using cURL in the command line:
+
+```bash
+curl -H 'Content-Type: application/json' /
+     -d '{"format": "MMMM d yyyy, h:mm:ss a"}' /
+     <function url>/date
+```
+Formatted dates should be displayed.
+
+We are responding with a 403 error in case of PUT requests:
+
+```bash
+curl -X PUT -d '{"format": "MMMM d yyyy, h:mm:ss a"}' <function-url>/date
+```
+
+
+## Contributing
+
+We'd love that you contribute to the project. Before doing so please read our [Contributor guide](../../CONTRIBUTING.md).
+
+
+## License
+
+© Google, 2026. Licensed under an [Apache-2](../../../LICENSE) license.

--- a/Dart/quickstarts/https-time-server/bin/server.dart
+++ b/Dart/quickstarts/https-time-server/bin/server.dart
@@ -1,0 +1,91 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START dartHttpImport]
+import 'package:firebase_functions/firebase_functions.dart';
+// [END dartHttpImport]
+
+// [START dartHttpAdditionalImports]
+import 'dart:convert';
+import 'package:intl/intl.dart';
+// [END dartHttpAdditionalImports]
+
+// [START dartHttpAll]
+/// Returns the server's date.
+/// Options `timeoutSeconds` and `region` are optional.
+///
+/// You must provide a `format` URL query parameter or `format` value in
+/// the request body with which we'll try to format the date.
+///
+/// Format must follow the Dart intl library. See: https://pub.dev/packages/intl
+///
+/// Example format: "MMMM d yyyy, h:mm:ss a".
+/// Example request using URL query parameters:
+///   https://us-central1-<project-id>.cloudfunctions.net/date?format=MMMM%20d%20yyyy%2C%20h%3Amm%3Ass%20a
+/// Example request using request body with cURL:
+///   curl -H 'Content-Type: application/json' /
+///        -d '{"format": "MMMM d yyyy, h:mm:ss a"}' /
+///        https://us-central1-<project-id>.cloudfunctions.net/date
+void main(List<String> args) async {
+  await fireUp(args, (firebase) {
+    // [START dartHttpTrigger]
+    firebase.https.onRequest(
+      name: 'date',
+      // ignore: non_const_argument_for_const_parameter
+      options: HttpsOptions(timeoutSeconds: TimeoutSeconds(1200)),
+      (request) async {
+        // [END dartHttpTrigger]
+
+        // [START dartHttpSendError]
+        // Forbidding PUT requests.
+        if (request.method == 'PUT') {
+          return Response.forbidden('Forbidden!');
+        }
+        // [END dartHttpSendError]
+
+        // Reading date format from URL query parameter.
+        // [START dartHttpReadQueryParam]
+        var format = request.url.queryParameters['format'];
+        // [END dartHttpReadQueryParam]
+
+        // Reading date format from request body query parameter
+        if (format == null) {
+          // [START dartHttpReadBodyParam]
+          final bodyString = await request.readAsString();
+          try {
+            if (bodyString.isNotEmpty) {
+              final body = jsonDecode(bodyString) as Map<String, dynamic>;
+              format = body['format'] as String?;
+            }
+          } catch (e) {
+            // Ignore JSON parsing errors
+          }
+          // [END dartHttpReadBodyParam]
+        }
+
+        if (format == null) {
+          return Response(400, body: 'Format string missing');
+        }
+
+        // [START dartHttpSendResponse]
+        final formattedDate = DateFormat(format).format(DateTime.now());
+        print('Sending formatted date: $formattedDate');
+        return Response.ok(formattedDate);
+        // [END dartHttpSendResponse]
+      },
+    );
+  });
+}
+
+// [END dartHttpAll]

--- a/Dart/quickstarts/https-time-server/bin/server.dart
+++ b/Dart/quickstarts/https-time-server/bin/server.dart
@@ -40,51 +40,44 @@ import 'package:intl/intl.dart';
 void main(List<String> args) async {
   await fireUp(args, (firebase) {
     // [START dartHttpTrigger]
-    firebase.https.onRequest(
-      name: 'date',
-      // ignore: non_const_argument_for_const_parameter
-      options: HttpsOptions(timeoutSeconds: TimeoutSeconds(1200)),
-      (request) async {
-        // [END dartHttpTrigger]
+    firebase.https.onRequest(name: 'date', (request) async {
+      // [END dartHttpTrigger]
 
-        // [START dartHttpSendError]
-        // Forbidding PUT requests.
-        if (request.method == 'PUT') {
-          return Response.forbidden('Forbidden!');
-        }
-        // [END dartHttpSendError]
+      // [START dartHttpSendError]
+      // Forbidding PUT requests.
+      if (request.method == 'PUT') {
+        return Response.forbidden('Forbidden!');
+      }
+      // [END dartHttpSendError]
 
-        // Reading date format from URL query parameter.
-        // [START dartHttpReadQueryParam]
-        var format = request.url.queryParameters['format'];
-        // [END dartHttpReadQueryParam]
+      // Reading date format from URL query parameter.
+      // [START dartHttpReadQueryParam]
+      var format = request.url.queryParameters['format'];
+      // [END dartHttpReadQueryParam]
 
-        // Reading date format from request body query parameter
-        if (format == null) {
-          // [START dartHttpReadBodyParam]
-          final bodyString = await request.readAsString();
-          try {
-            if (bodyString.isNotEmpty) {
-              final body = jsonDecode(bodyString) as Map<String, dynamic>;
-              format = body['format'] as String?;
-            }
-          } catch (e) {
-            // Ignore JSON parsing errors
+      // Reading date format from request body query parameter
+      if (format == null) {
+        // [START dartHttpReadBodyParam]
+        final bodyString = await request.readAsString();
+        try {
+          if (bodyString.isNotEmpty) {
+            final body = jsonDecode(bodyString) as Map<String, dynamic>;
+            format = body['format'] as String?;
           }
-          // [END dartHttpReadBodyParam]
+        } catch (e) {
+          // Ignore JSON parsing errors
         }
+        // [END dartHttpReadBodyParam]
+      }
 
-        if (format == null) {
-          return Response(400, body: 'Format string missing');
-        }
-
-        // [START dartHttpSendResponse]
-        final formattedDate = DateFormat(format).format(DateTime.now());
-        print('Sending formatted date: $formattedDate');
-        return Response.ok(formattedDate);
-        // [END dartHttpSendResponse]
-      },
-    );
+      // [START dartHttpSendResponse]
+      final formattedDate = format != null
+          ? DateFormat(format).format(DateTime.now())
+          : DateTime.now().toString();
+      print('Sending formatted date: $formattedDate');
+      return Response.ok(formattedDate);
+      // [END dartHttpSendResponse]
+    });
   });
 }
 

--- a/Dart/quickstarts/https-time-server/bin/server.dart
+++ b/Dart/quickstarts/https-time-server/bin/server.dart
@@ -32,11 +32,11 @@ import 'package:intl/intl.dart';
 ///
 /// Example format: "MMMM d yyyy, h:mm:ss a".
 /// Example request using URL query parameters:
-///   https://us-central1-<project-id>.cloudfunctions.net/date?format=MMMM%20d%20yyyy%2C%20h%3Amm%3Ass%20a
+///   https://date-<random-hash>.<region>.run.app?format=MMMM%20d%20yyyy%2C%20h%3Amm%3Ass%20a
 /// Example request using request body with cURL:
 ///   curl -H 'Content-Type: application/json' /
 ///        -d '{"format": "MMMM d yyyy, h:mm:ss a"}' /
-///        https://us-central1-<project-id>.cloudfunctions.net/date
+///        https://date-<random-hash>.<region>.run.app
 void main(List<String> args) async {
   await fireUp(args, (firebase) {
     // [START dartHttpTrigger]
@@ -65,15 +65,16 @@ void main(List<String> args) async {
             format = body['format'] as String?;
           }
         } catch (e) {
-          // Ignore JSON parsing errors
+          return Response.badRequest(body: 'invalid JSON');
         }
         // [END dartHttpReadBodyParam]
       }
 
+      // Set a default format if none was provided
+      format ??= 'MMMM d yyyy, h:mm:ss a';
+
       // [START dartHttpSendResponse]
-      final formattedDate = format != null
-          ? DateFormat(format).format(DateTime.now())
-          : DateTime.now().toString();
+      final formattedDate = DateFormat(format).format(DateTime.now());
       print('Sending formatted date: $formattedDate');
       return Response.ok(formattedDate);
       // [END dartHttpSendResponse]

--- a/Dart/quickstarts/https-time-server/firebase.json
+++ b/Dart/quickstarts/https-time-server/firebase.json
@@ -1,0 +1,6 @@
+{
+  "functions": {
+    "source": ".",
+    "codebase": "dart-quickstarts-https-time-server"
+  }
+}

--- a/Dart/quickstarts/https-time-server/pubspec.yaml
+++ b/Dart/quickstarts/https-time-server/pubspec.yaml
@@ -1,0 +1,43 @@
+name: https_time_server
+description: HTTPS trigger examples for Firebase Functions for Dart
+publish_to: none
+
+environment:
+  sdk: ^3.7.0
+
+dependencies:
+  firebase_functions:
+    git:
+      url: https://github.com/firebase/firebase-functions-dart
+      ref: main
+  dart_firebase_admin:
+    git:
+      url: https://github.com/firebase/firebase-admin-dart
+      path: packages/dart_firebase_admin
+      ref: main
+  google_cloud_firestore:
+    git:
+      url: https://github.com/firebase/firebase-admin-dart
+      path: packages/google_cloud_firestore
+      ref: main
+  intl: ^0.20.2
+
+dev_dependencies:
+  build_runner: ^2.10.5
+  lints: ^6.0.0
+
+dependency_overrides:
+  firebase_functions:
+    git:
+      url: https://github.com/firebase/firebase-functions-dart
+      ref: main
+  dart_firebase_admin:
+    git:
+      url: https://github.com/firebase/firebase-admin-dart
+      path: packages/dart_firebase_admin
+      ref: main
+  google_cloud_firestore:
+    git:
+      url: https://github.com/firebase/firebase-admin-dart
+      path: packages/google_cloud_firestore
+      ref: main

--- a/Dart/quickstarts/https-time-server/pubspec.yaml
+++ b/Dart/quickstarts/https-time-server/pubspec.yaml
@@ -27,17 +27,13 @@ dev_dependencies:
   lints: ^6.0.0
 
 dependency_overrides:
-  firebase_functions:
-    git:
-      url: https://github.com/firebase/firebase-functions-dart
-      ref: main
   dart_firebase_admin:
-    git:
-      url: https://github.com/firebase/firebase-admin-dart
-      path: packages/dart_firebase_admin
-      ref: main
+      git:
+        url: https://github.com/firebase/firebase-admin-dart
+        path: packages/dart_firebase_admin
+        ref: main
   google_cloud_firestore:
-    git:
-      url: https://github.com/firebase/firebase-admin-dart
-      path: packages/google_cloud_firestore
-      ref: main
+      git:
+        url: https://github.com/firebase/firebase-admin-dart
+        path: packages/google_cloud_firestore
+        ref: main

--- a/Dart/quickstarts/https-time-server/pubspec.yaml
+++ b/Dart/quickstarts/https-time-server/pubspec.yaml
@@ -3,7 +3,7 @@ description: HTTPS trigger examples for Firebase Functions for Dart
 publish_to: none
 
 environment:
-  sdk: ^3.7.0
+  sdk: ^3.11.0
 
 dependencies:
   firebase_functions:

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ This quickstart sample demonstrates using **Cloud Functions** triggered by **Fir
 
 ### HTTPS trigger quickstart: Time Server
 
+- [Dart](/Dart/quickstarts/https-time-server/)
 - [Node 2nd gen](/Node/quickstarts/https-time-server/)
 - [Python](/Python/quickstarts/https-time-server/)
 - [Node 1st gen](/Node-1st-gen/quickstarts/https-time-server/)


### PR DESCRIPTION
Adds a Dart quickstart for the HTTPS trigger function, implementing the time-server functionality with `intl` for date formatting, and sets up a CI workflow for Dart.

---
*PR created automatically by Jules for task [695963262136015593](https://jules.google.com/task/695963262136015593) started by @jhuleatt*