### PR TITLE
Update Python requirements to latest `firebase-functions` and `firebase-admin`

### DIFF
--- a/Python/alerts-to-discord/functions/requirements.txt
+++ b/Python/alerts-to-discord/functions/requirements.txt
@@ -1,2 +1,2 @@
-firebase-functions
+firebase-functions ~= 0.5.0
 requests

--- a/Python/delete-unused-accounts-cron/functions/requirements.txt
+++ b/Python/delete-unused-accounts-cron/functions/requirements.txt
@@ -1,2 +1,2 @@
-firebase-functions
-firebase-admin
+firebase-functions ~= 0.5.0
+firebase-admin ~= 7.4.0

--- a/Python/fcm-notifications/functions/requirements.txt
+++ b/Python/fcm-notifications/functions/requirements.txt
@@ -1,1 +1,1 @@
-firebase_functions~=0.1.0
+firebase-functions ~= 0.5.0

--- a/Python/http-flask/functions/requirements.txt
+++ b/Python/http-flask/functions/requirements.txt
@@ -1,3 +1,3 @@
-firebase-admin
-firebase-functions
+firebase-admin ~= 7.4.0
+firebase-functions ~= 0.5.0
 flask

--- a/Python/post-signup-event/functions/requirements.txt
+++ b/Python/post-signup-event/functions/requirements.txt
@@ -1,5 +1,5 @@
-firebase-functions
-firebase-admin
+firebase-functions ~= 0.5.0
+firebase-admin ~= 7.4.0
 google-auth
 google-api-python-client
 google-cloud-tasks

--- a/Python/quickstarts/auth-blocking-functions/functions/requirements.txt
+++ b/Python/quickstarts/auth-blocking-functions/functions/requirements.txt
@@ -1,2 +1,2 @@
-firebase-functions
-firebase-admin
+firebase-functions ~= 0.5.0
+firebase-admin ~= 7.4.0

--- a/Python/quickstarts/callable-functions/functions/requirements.txt
+++ b/Python/quickstarts/callable-functions/functions/requirements.txt
@@ -1,2 +1,2 @@
-firebase-functions
-firebase-admin
+firebase-functions ~= 0.5.0
+firebase-admin ~= 7.4.0

--- a/Python/quickstarts/custom-events/functions/requirements.txt
+++ b/Python/quickstarts/custom-events/functions/requirements.txt
@@ -1,2 +1,2 @@
-firebase-functions
-firebase-admin
+firebase-functions ~= 0.5.0
+firebase-admin ~= 7.4.0

--- a/Python/quickstarts/firestore-sync-auth/functions/requirements.txt
+++ b/Python/quickstarts/firestore-sync-auth/functions/requirements.txt
@@ -1,2 +1,2 @@
-firebase-functions
-firebase-admin
+firebase-functions ~= 0.5.0
+firebase-admin ~= 7.4.0

--- a/Python/quickstarts/https-time-server/functions/requirements.txt
+++ b/Python/quickstarts/https-time-server/functions/requirements.txt
@@ -1,1 +1,1 @@
-firebase-functions
+firebase-functions ~= 0.5.0

--- a/Python/quickstarts/monitor-cloud-logging/functions/requirements.txt
+++ b/Python/quickstarts/monitor-cloud-logging/functions/requirements.txt
@@ -1,1 +1,1 @@
-firebase_functions~=0.1.2
+firebase-functions ~= 0.5.0

--- a/Python/quickstarts/pubsub-helloworld/functions/requirements.txt
+++ b/Python/quickstarts/pubsub-helloworld/functions/requirements.txt
@@ -1,1 +1,1 @@
-firebase-functions
+firebase-functions ~= 0.5.0

--- a/Python/quickstarts/uppercase-firestore/functions/requirements.txt
+++ b/Python/quickstarts/uppercase-firestore/functions/requirements.txt
@@ -1,2 +1,2 @@
-firebase-functions
-firebase-admin
+firebase-functions ~= 0.5.0
+firebase-admin ~= 7.4.0

--- a/Python/quickstarts/uppercase-rtdb/functions/requirements.txt
+++ b/Python/quickstarts/uppercase-rtdb/functions/requirements.txt
@@ -1,2 +1,2 @@
-firebase-functions
-firebase-admin
+firebase-functions ~= 0.5.0
+firebase-admin ~= 7.4.0

--- a/Python/remote-config-diff/functions/requirements.txt
+++ b/Python/remote-config-diff/functions/requirements.txt
@@ -1,4 +1,4 @@
-firebase-functions
-firebase-admin
+firebase-functions ~= 0.5.0
+firebase-admin ~= 7.4.0
 deepdiff
 requests

--- a/Python/taskqueues-backup-images/functions/requirements.txt
+++ b/Python/taskqueues-backup-images/functions/requirements.txt
@@ -1,5 +1,5 @@
-firebase-functions
-firebase-admin
+firebase-functions ~= 0.5.0
+firebase-admin ~= 7.4.0
 google-auth
 google-cloud-tasks
 requests

--- a/Python/testlab-to-slack/functions/requirements.txt
+++ b/Python/testlab-to-slack/functions/requirements.txt
@@ -1,2 +1,2 @@
-firebase-functions
+firebase-functions ~= 0.5.0
 requests

--- a/Python/thumbnails/functions/requirements.txt
+++ b/Python/thumbnails/functions/requirements.txt
@@ -1,3 +1,3 @@
-firebase-functions
-firebase-admin
+firebase-functions ~= 0.5.0
+firebase-admin ~= 7.4.0
 pillow


### PR DESCRIPTION
Updated all Python requirements.txt to use `firebase-functions ~= 0.5.0` and `firebase-admin ~= 7.4.0` in order to use the latest versions while preventing future major version bumps from breaking the samples.

---
*PR created automatically by Jules for task [5009605169601225659](https://jules.google.com/task/5009605169601225659) started by @jhuleatt*