### PR TITLE
docs: add README for Dart multi_counter sample

### DIFF
--- a/Dart/multi_counter/README.md
+++ b/Dart/multi_counter/README.md
@@ -4,6 +4,7 @@ This is sample code from a talk at Cloud Next 2026.
 
 [Unify your tech stack with Dart](https://www.googlecloudevents.com/next-vegas/session-library?session_id=3911912&name=unify-your-tech-stack-with-dart)
 
-This repository contains two projects:
+This sample contains three projects:
 - `app/` A Flutter application for a shared multi-counter.
 - `server/` A Cloud Functions for Firebase project containing functions for the multi-counter written in Dart.
+- `shared/` A shared Dart package containing logic and models used by both the app and the server.

--- a/Dart/multi_counter/README.md
+++ b/Dart/multi_counter/README.md
@@ -1,0 +1,9 @@
+# Multi-counter
+
+This is sample code from a talk at Cloud Next 2026.
+
+[Unify your tech stack with Dart](https://www.googlecloudevents.com/next-vegas/session-library?session_id=3911912&name=unify-your-tech-stack-with-dart)
+
+This repository contains two projects:
+- `app/` A Flutter application for a shared multi-counter.
+- `server/` A Cloud Functions for Firebase project containing functions for the multi-counter written in Dart.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Minimal samples for each Cloud Functions trigger type.
 
 - [Dart](/Dart/multi_counter/)
 
-This sample contains both a Flutter app and a Dart server-side Cloud Function showcasing how to build a multi-counter application, as featured in a Cloud Next 2026 talk.
+This sample contains a Flutter app, a shared Dart package, and Dart server-side Cloud Functions showcasing how to build a multi-counter application, as featured in a Cloud Next 2026 talk.
 
 ### Quickstart: Uppercaser for Firestore
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ To learn how to get started with Cloud Functions for Firebase by having a look a
 
 Minimal samples for each Cloud Functions trigger type.
 
+### Multi-counter
+
+- [Dart](/Dart/multi_counter/)
+
+This sample contains both a Flutter app and a Dart server-side Cloud Function showcasing how to build a multi-counter application, as featured in a Cloud Next 2026 talk.
+
 ### Quickstart: Uppercaser for Firestore
 
 - [Node 2nd gen](/Node/quickstarts/uppercase-firestore/)


### PR DESCRIPTION
Adds a `README.md` to the `Dart/multi_counter` sample with information about the Cloud Next 2026 talk and the session link. It also adds a reference to the sample in the root `README.md`.

---
*PR created automatically by Jules for task [2165079252949837490](https://jules.google.com/task/2165079252949837490) started by @jhuleatt*