### PR TITLE
chore(dart): Use published pub.dev versions for Firebase dependencies

### DIFF
--- a/Dart/quickstarts/callable-functions-streaming/pubspec.yaml
+++ b/Dart/quickstarts/callable-functions-streaming/pubspec.yaml
@@ -6,28 +6,9 @@ environment:
   sdk: ^3.11.0
 
 dependencies:
-  firebase_functions:
-    git:
-      url: https://github.com/firebase/firebase-functions-dart
-      ref: main
+  firebase_functions: ^0.5.0
   http: ^1.2.0
 
 dev_dependencies:
   build_runner: ^2.10.5
   lints: ^6.0.0
-
-dependency_overrides:
-  firebase_functions:
-    git:
-      url: https://github.com/firebase/firebase-functions-dart
-      ref: main
-  firebase_admin_sdk:
-    git:
-      url: https://github.com/firebase/firebase-admin-dart
-      path: packages/firebase_admin_sdk
-      ref: main
-  google_cloud_firestore:
-    git:
-      url: https://github.com/firebase/firebase-admin-dart
-      path: packages/google_cloud_firestore
-      ref: main

--- a/Dart/quickstarts/callable-functions/pubspec.yaml
+++ b/Dart/quickstarts/callable-functions/pubspec.yaml
@@ -6,27 +6,8 @@ environment:
   sdk: ^3.11.0
 
 dependencies:
-  firebase_functions:
-    git:
-      url: https://github.com/firebase/firebase-functions-dart
-      ref: main
+  firebase_functions: ^0.5.0
 
 dev_dependencies:
   build_runner: ^2.10.5
   lints: ^6.0.0
-
-dependency_overrides:
-  firebase_functions:
-    git:
-      url: https://github.com/firebase/firebase-functions-dart
-      ref: main
-  firebase_admin_sdk:
-      git:
-        url: https://github.com/firebase/firebase-admin-dart
-        path: packages/firebase_admin_sdk
-        ref: main
-  google_cloud_firestore:
-      git:
-        url: https://github.com/firebase/firebase-admin-dart
-        path: packages/google_cloud_firestore
-        ref: main

--- a/Dart/quickstarts/https-time-server/pubspec.yaml
+++ b/Dart/quickstarts/https-time-server/pubspec.yaml
@@ -6,34 +6,11 @@ environment:
   sdk: ^3.11.0
 
 dependencies:
-  firebase_functions:
-    git:
-      url: https://github.com/firebase/firebase-functions-dart
-      ref: main
-  firebase_admin_sdk:
-    git:
-      url: https://github.com/firebase/firebase-admin-dart
-      path: packages/firebase_admin_sdk
-      ref: main
-  google_cloud_firestore:
-    git:
-      url: https://github.com/firebase/firebase-admin-dart
-      path: packages/google_cloud_firestore
-      ref: main
+  firebase_functions: ^0.5.0
+  firebase_admin_sdk: ^0.5.0
+  google_cloud_firestore: ^0.5.0
   intl: ^0.20.2
 
 dev_dependencies:
   build_runner: ^2.10.5
   lints: ^6.0.0
-
-dependency_overrides:
-  firebase_admin_sdk:
-      git:
-        url: https://github.com/firebase/firebase-admin-dart
-        path: packages/firebase_admin_sdk
-        ref: main
-  google_cloud_firestore:
-      git:
-        url: https://github.com/firebase/firebase-admin-dart
-        path: packages/google_cloud_firestore
-        ref: main

--- a/Dart/quickstarts/resize-image/pubspec.yaml
+++ b/Dart/quickstarts/resize-image/pubspec.yaml
@@ -8,24 +8,9 @@ environment:
 dependencies:
   image: ^4.8.0
   path: ^1.9.1
-  firebase_functions:
-    git:
-      url: https://github.com/firebase/firebase-functions-dart
-      ref: main
+  firebase_functions: ^0.5.0
   intl: ^0.20.2
 
 dev_dependencies:
   build_runner: ^2.10.5
   lints: ^6.0.0
-
-dependency_overrides:
-  firebase_admin_sdk:
-      git:
-        url: https://github.com/firebase/firebase-admin-dart
-        path: packages/firebase_admin_sdk
-        ref: main
-  google_cloud_firestore:
-      git:
-        url: https://github.com/firebase/firebase-admin-dart
-        path: packages/google_cloud_firestore
-        ref: main


### PR DESCRIPTION
This PR replaces the `git` dependencies and `dependency_overrides` blocks in all Dart quickstart `pubspec.yaml` files with the published `^0.5.0` versions for `firebase_functions`, `firebase_admin_sdk`, and `google_cloud_firestore` from pub.dev.

---
*PR created automatically by Jules for task [17143255474696196670](https://jules.google.com/task/17143255474696196670) started by @jhuleatt*